### PR TITLE
do not create virtual display for null surface

### DIFF
--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/VirtualRenderer.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/VirtualRenderer.kt
@@ -88,6 +88,11 @@ class VirtualRenderer(
             var visibleArea = Rect(0, 0, 0, 0)
 
             override fun onSurfaceAvailable(surfaceContainer: SurfaceContainer) {
+                if (surfaceContainer.surface == null) {
+                    Log.w(TAG, "surface is null")
+                    return
+                }
+
                 val manager = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
                 val virtualDisplay = manager.createVirtualDisplay(
                     moduleName,


### PR DESCRIPTION
Check if surface is defined, before creating a VirtualDisplay with it.