### PR TITLE
fix: carplay template button update race condition

### DIFF
--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridAutoPlay.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridAutoPlay.kt
@@ -72,12 +72,14 @@ class HybridAutoPlay : HybridAutoPlaySpec() {
 
     override fun setTemplateHeaderActions(
         templateId: String, headerActions: Array<NitroAction>?
-    ) {
-        val template =
-            AndroidAutoTemplate.getTemplate(templateId) ?: throw IllegalArgumentException(
-                "setTemplateHeaderActions failed, template $templateId not found"
-            )
-        template.setTemplateHeaderActions(headerActions)
+    ): Promise<Unit> {
+        return Promise.async {
+            val template =
+                AndroidAutoTemplate.getTemplate(templateId) ?: throw IllegalArgumentException(
+                    "setTemplateHeaderActions failed, template $templateId not found"
+                )
+            template.setTemplateHeaderActions(headerActions)
+        }
     }
 
     override fun setRootTemplate(templateId: String): Promise<Unit> {
@@ -105,9 +107,8 @@ class HybridAutoPlay : HybridAutoPlaySpec() {
             } else {
                 val screenManager = AndroidAutoScreen.getScreenManager()
                     ?: throw IllegalArgumentException("setRootTemplate failed, screenManager not found")
-                val carContext =
-                    AndroidAutoSession.getCarContext(AndroidAutoSession.ROOT_SESSION)
-                        ?: throw IllegalArgumentException("setRootTemplate failed, carContext for $templateId template not found")
+                val carContext = AndroidAutoSession.getCarContext(AndroidAutoSession.ROOT_SESSION)
+                    ?: throw IllegalArgumentException("setRootTemplate failed, carContext for $templateId template not found")
 
                 val result = ThreadUtil.postOnUiAndAwait {
                     screenManager.popToRoot()

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridGridTemplate.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridGridTemplate.kt
@@ -1,5 +1,6 @@
 package com.margelo.nitro.swe.iternio.reactnativeautoplay
 
+import com.margelo.nitro.core.Promise
 import com.margelo.nitro.swe.iternio.reactnativeautoplay.template.AndroidAutoTemplate
 import com.margelo.nitro.swe.iternio.reactnativeautoplay.template.GridTemplate
 
@@ -14,8 +15,10 @@ class HybridGridTemplate : HybridGridTemplateSpec() {
 
     override fun updateGridTemplateButtons(
         templateId: String, buttons: Array<NitroGridButton>
-    ) {
-        val template = AndroidAutoTemplate.getTemplate<GridTemplate>(templateId)
-        template.updateButtons(buttons)
+    ): Promise<Unit> {
+        return Promise.async {
+            val template = AndroidAutoTemplate.getTemplate<GridTemplate>(templateId)
+            template.updateButtons(buttons)
+        }
     }
 }

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridInformationTemplate.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridInformationTemplate.kt
@@ -1,5 +1,6 @@
 package com.margelo.nitro.swe.iternio.reactnativeautoplay
 
+import com.margelo.nitro.core.Promise
 import com.margelo.nitro.swe.iternio.reactnativeautoplay.template.AndroidAutoTemplate
 import com.margelo.nitro.swe.iternio.reactnativeautoplay.template.InformationTemplate
 
@@ -13,10 +14,11 @@ class HybridInformationTemplate : HybridInformationTemplateSpec() {
     }
 
     override fun updateInformationTemplateSections(
-        templateId: String,
-        section: NitroSection
-    ) {
-        val template = AndroidAutoTemplate.getTemplate<InformationTemplate>(templateId)
-        template.updateSection(section)
+        templateId: String, section: NitroSection
+    ): Promise<Unit> {
+        return Promise.async {
+            val template = AndroidAutoTemplate.getTemplate<InformationTemplate>(templateId)
+            template.updateSection(section)
+        }
     }
 }

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridListTemplate.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridListTemplate.kt
@@ -1,5 +1,6 @@
 package com.margelo.nitro.swe.iternio.reactnativeautoplay
 
+import com.margelo.nitro.core.Promise
 import com.margelo.nitro.swe.iternio.reactnativeautoplay.template.AndroidAutoTemplate
 import com.margelo.nitro.swe.iternio.reactnativeautoplay.template.ListTemplate
 
@@ -15,8 +16,10 @@ class HybridListTemplate : HybridListTemplateSpec() {
 
     override fun updateListTemplateSections(
         templateId: String, sections: Array<NitroSection>?
-    ) {
-        val template = AndroidAutoTemplate.getTemplate<ListTemplate>(templateId)
-        template.updateSections(sections)
+    ): Promise<Unit> {
+        return Promise.async {
+            val template = AndroidAutoTemplate.getTemplate<ListTemplate>(templateId)
+            template.updateSections(sections)
+        }
     }
 }

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridMapTemplate.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridMapTemplate.kt
@@ -2,6 +2,7 @@ package com.margelo.nitro.swe.iternio.reactnativeautoplay
 
 import androidx.car.app.AppManager
 import com.facebook.react.bridge.UiThreadUtil
+import com.margelo.nitro.core.Promise
 import com.margelo.nitro.swe.iternio.reactnativeautoplay.template.AndroidAutoTemplate
 import com.margelo.nitro.swe.iternio.reactnativeautoplay.template.MapTemplate
 import com.margelo.nitro.swe.iternio.reactnativeautoplay.template.RoutePreviewTemplate
@@ -120,9 +121,11 @@ class HybridMapTemplate : HybridMapTemplateSpec() {
 
     override fun setTemplateMapButtons(
         templateId: String, buttons: Array<NitroMapButton>?
-    ) {
-        val template = AndroidAutoTemplate.getTemplate<MapTemplate>(templateId)
-        template.setMapActions(buttons)
+    ): Promise<Unit> {
+        return Promise.async {
+            val template = AndroidAutoTemplate.getTemplate<MapTemplate>(templateId)
+            template.setMapActions(buttons)
+        }
     }
 
     override fun updateVisibleTravelEstimate(

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridSearchTemplate.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridSearchTemplate.kt
@@ -1,5 +1,6 @@
 package com.margelo.nitro.swe.iternio.reactnativeautoplay
 
+import com.margelo.nitro.core.Promise
 import com.margelo.nitro.swe.iternio.reactnativeautoplay.template.AndroidAutoTemplate
 import com.margelo.nitro.swe.iternio.reactnativeautoplay.template.SearchTemplate
 
@@ -13,8 +14,10 @@ class HybridSearchTemplate : HybridSearchTemplateSpec() {
         AndroidAutoTemplate.setTemplate(config.id, template)
     }
 
-    override fun updateSearchResults(templateId: String, results: NitroSection) {
-        val template = AndroidAutoTemplate.getTemplate<SearchTemplate>(templateId)
-        template.updateSearchResults(results)
+    override fun updateSearchResults(templateId: String, results: NitroSection): Promise<Unit> {
+        return Promise.async {
+            val template = AndroidAutoTemplate.getTemplate<SearchTemplate>(templateId)
+            template.updateSearchResults(results)
+        }
     }
 }

--- a/packages/react-native-autoplay/ios/hybrid/HybridGridTemplate.swift
+++ b/packages/react-native-autoplay/ios/hybrid/HybridGridTemplate.swift
@@ -5,24 +5,31 @@
 //  Created by Manuel Auer on 15.10.25.
 //
 
+import NitroModules
+
 class HybridGridTemplate: HybridGridTemplateSpec {
     func createGridTemplate(config: GridTemplateConfig) throws {
         let template = GridTemplate(config: config)
-        try RootModule.withScene { scene in
-            scene.templateStore.addTemplate(
-                template: template,
-                templateId: config.id
-            )
-        }
+
+        TemplateStore.addTemplate(
+            template: template,
+            templateId: config.id
+        )
     }
 
     func updateGridTemplateButtons(
         templateId: String,
         buttons: [NitroGridButton]
-    ) throws {
-        try RootModule.withAutoPlayTemplate(templateId: templateId) {
-            (template: GridTemplate) in
-            template.updateButtons(buttons: buttons)
+    ) throws -> Promise<Void> {
+        return Promise.async {
+            guard
+                let template = TemplateStore.getTemplate(templateId: templateId)
+                    as? GridTemplate
+            else {
+                throw AutoPlayError.templateNotFound(templateId)
+            }
+
+            await template.updateButtons(buttons: buttons)
         }
     }
 }

--- a/packages/react-native-autoplay/ios/hybrid/HybridInformationTemplate.swift
+++ b/packages/react-native-autoplay/ios/hybrid/HybridInformationTemplate.swift
@@ -5,25 +5,33 @@
 //  Created by Samuel Brucksch on 05.11.25.
 //
 
+import NitroModules
+
 class HybridInformationTemplate: HybridInformationTemplateSpec {
 
     func createInformationTemplate(config: InformationTemplateConfig) throws {
         let template = InformationTemplate(config: config)
-        try RootModule.withScene { scene in
-            scene.templateStore.addTemplate(
-                template: template,
-                templateId: config.id
-            )
-        }
+        TemplateStore.addTemplate(
+            template: template,
+            templateId: config.id
+        )
     }
 
     func updateInformationTemplateSections(
         templateId: String,
         section: NitroSection
-    ) throws {
-        try RootModule.withAutoPlayTemplate(templateId: templateId) {
-            (template: InformationTemplate) in
-            template.updateSection(section: section)
+    ) throws -> Promise<Void> {
+        return Promise.async {
+            guard
+                let template = TemplateStore.getTemplate(templateId: templateId)
+                    as? InformationTemplate
+            else {
+                throw AutoPlayError.invalidTemplateType(
+                    "\(templateId) is not an InformationTemplate"
+                )
+            }
+
+            await template.updateSection(section: section)
         }
     }
 }

--- a/packages/react-native-autoplay/ios/hybrid/HybridListTemplate.swift
+++ b/packages/react-native-autoplay/ios/hybrid/HybridListTemplate.swift
@@ -5,24 +5,32 @@
 //  Created by Manuel Auer on 15.10.25.
 //
 
+import NitroModules
+
 class HybridListTemplate: HybridListTemplateSpec {
     func createListTemplate(config: ListTemplateConfig) throws {
         let template = ListTemplate(config: config)
-        try RootModule.withScene { scene in
-            scene.templateStore.addTemplate(
-                template: template,
-                templateId: config.id
-            )
-        }
+        TemplateStore.addTemplate(
+            template: template,
+            templateId: config.id
+        )
     }
 
     func updateListTemplateSections(
         templateId: String,
         sections: [NitroSection]?
-    ) throws {
-        try RootModule.withAutoPlayTemplate(templateId: templateId) {
-            (template: ListTemplate) in
-            template.updateSections(sections: sections)
+    ) throws -> Promise<Void> {
+        return Promise.async {
+            guard
+                let template = TemplateStore.getTemplate(templateId: templateId)
+                    as? ListTemplate
+            else {
+                throw AutoPlayError.invalidTemplateType(
+                    "\(templateId) is not a ListTemplate"
+                )
+            }
+
+            await template.updateSections(sections: sections)
         }
     }
 }

--- a/packages/react-native-autoplay/ios/hybrid/HybridMapTemplate.swift
+++ b/packages/react-native-autoplay/ios/hybrid/HybridMapTemplate.swift
@@ -6,26 +6,34 @@
 //
 
 import CarPlay
+import NitroModules
 
 class HybridMapTemplate: HybridMapTemplateSpec {
     func createMapTemplate(config: MapTemplateConfig) throws {
         let template = MapTemplate(config: config)
-        try RootModule.withScene { scene in
-            scene.templateStore.addTemplate(
-                template: template,
-                templateId: config.id
-            )
-        }
+        TemplateStore.addTemplate(
+            template: template,
+            templateId: config.id
+        )
     }
 
     func setTemplateMapButtons(templateId: String, buttons: [NitroMapButton]?)
-        throws
+        throws -> Promise<Void>
     {
-        try RootModule.withAutoPlayTemplate(templateId: templateId) {
-            (template: MapTemplate) in
-
-            template.config.mapButtons = buttons
-            template.invalidate()
+        return Promise.async {
+            guard
+                let template = TemplateStore.getTemplate(templateId: templateId)
+                    as? MapTemplate
+            else {
+                throw AutoPlayError.invalidTemplateError(
+                    "\(templateId) is not a MapTemplate"
+                )
+            }
+            
+            await MainActor.run {
+                template.config.mapButtons = buttons
+                template.invalidate()
+            }
         }
     }
 

--- a/packages/react-native-autoplay/ios/hybrid/HybridMessageTemplate.swift
+++ b/packages/react-native-autoplay/ios/hybrid/HybridMessageTemplate.swift
@@ -8,12 +8,9 @@
 class HybridMessageTemplate: HybridMessageTemplateSpec {
     func createMessageTemplate(config: MessageTemplateConfig) throws {
         let template = MessageTemplate(config: config)
-        
-        try RootModule.withScene { scene in
-            scene.templateStore.addTemplate(
-                template: template,
-                templateId: config.id
-            )
-        }
+        TemplateStore.addTemplate(
+            template: template,
+            templateId: config.id
+        )
     }
 }

--- a/packages/react-native-autoplay/ios/hybrid/HybridSearchTemplate.swift
+++ b/packages/react-native-autoplay/ios/hybrid/HybridSearchTemplate.swift
@@ -5,21 +5,31 @@
 //  Created by Samuel Brucksch on 28.10.25.
 //
 
+import NitroModules
+
 class HybridSearchTemplate: HybridSearchTemplateSpec {
     func createSearchTemplate(config: SearchTemplateConfig) throws {
         let template = SearchTemplate(config: config)
-        try RootModule.withScene { scene in
-            scene.templateStore.addTemplate(
-                template: template,
-                templateId: config.id
-            )
-        }
+        TemplateStore.addTemplate(
+            template: template,
+            templateId: config.id
+        )
     }
 
-    func updateSearchResults(templateId: String, results: NitroSection) throws {
-        try RootModule.withAutoPlayTemplate(templateId: templateId) {
-            (template: SearchTemplate) in
-            template.updateSearchResults(results: results)
+    func updateSearchResults(templateId: String, results: NitroSection) throws
+        -> Promise<Void>
+    {
+        return Promise.async {
+            guard
+                let template = TemplateStore.getTemplate(templateId: templateId)
+                    as? SearchTemplate
+            else {
+                throw AutoPlayError.invalidTemplateType(
+                    "\(templateId) is not a SearchTemplate"
+                )
+            }
+
+            await template.updateSearchResults(results: results)
         }
     }
 }

--- a/packages/react-native-autoplay/ios/scenes/AutoPlayInterfaceController.swift
+++ b/packages/react-native-autoplay/ios/scenes/AutoPlayInterfaceController.swift
@@ -10,14 +10,11 @@ import CarPlay
 @MainActor
 class AutoPlayInterfaceController: NSObject, CPInterfaceControllerDelegate {
     let interfaceController: CPInterfaceController
-    let templateStore: TemplateStore
 
     init(
-        interfaceController: CPInterfaceController,
-        templateStore: TemplateStore
+        interfaceController: CPInterfaceController
     ) {
         self.interfaceController = interfaceController
-        self.templateStore = templateStore
 
         super.init()
 
@@ -47,7 +44,7 @@ class AutoPlayInterfaceController: NSObject, CPInterfaceControllerDelegate {
     var rootTemplateId: String? {
         return interfaceController.rootTemplate.id
     }
-    
+
     func pushTemplate(
         _ templateToPush: CPTemplate,
         animated: Bool
@@ -77,7 +74,7 @@ class AutoPlayInterfaceController: NSObject, CPInterfaceControllerDelegate {
             animated: animated
         )
 
-        self.templateStore.removeTemplate(templateId: templateId)
+        TemplateStore.removeTemplate(templateId: templateId)
 
         return templateId
     }
@@ -100,7 +97,7 @@ class AutoPlayInterfaceController: NSObject, CPInterfaceControllerDelegate {
             animated: animated
         )
 
-        self.templateStore.removeTemplates(templateIds: templateIds)
+        TemplateStore.removeTemplates(templateIds: templateIds)
 
         return templateIds
     }
@@ -157,7 +154,7 @@ class AutoPlayInterfaceController: NSObject, CPInterfaceControllerDelegate {
         try await interfaceController.dismissTemplate(
             animated: animated
         )
-        
+
         return true
     }
 
@@ -168,7 +165,7 @@ class AutoPlayInterfaceController: NSObject, CPInterfaceControllerDelegate {
     ) {
         let templateId = aTemplate.id
 
-        templateStore.getTemplate(templateId: templateId)?.onWillAppear(
+        TemplateStore.getTemplate(templateId: templateId)?.onWillAppear(
             animated: animated
         )
     }
@@ -181,10 +178,10 @@ class AutoPlayInterfaceController: NSObject, CPInterfaceControllerDelegate {
 
         if rootTemplateId == templateId {
             // this makes sure we purge outdated CPSearchTemplate since that one can be popped on with a CarPlay native button we can not intercept
-            templateStore.purge()
+            TemplateStore.purge()
         }
 
-        templateStore.getTemplate(templateId: templateId)?.onDidAppear(
+        TemplateStore.getTemplate(templateId: templateId)?.onDidAppear(
             animated: animated
         )
     }
@@ -195,7 +192,7 @@ class AutoPlayInterfaceController: NSObject, CPInterfaceControllerDelegate {
     ) {
         let templateId = aTemplate.id
 
-        templateStore.getTemplate(templateId: templateId)?.onWillDisappear(
+        TemplateStore.getTemplate(templateId: templateId)?.onWillDisappear(
             animated: animated
         )
     }
@@ -206,12 +203,12 @@ class AutoPlayInterfaceController: NSObject, CPInterfaceControllerDelegate {
     ) {
         let templateId = aTemplate.id
 
-        templateStore.getTemplate(templateId: templateId)?.onDidDisappear(
+        TemplateStore.getTemplate(templateId: templateId)?.onDidDisappear(
             animated: animated
         )
 
         if aTemplate is CPAlertTemplate {
-            templateStore.removeTemplate(templateId: templateId)
+            TemplateStore.removeTemplate(templateId: templateId)
 
             HybridAutoPlay.removeListeners(
                 templateId: templateId

--- a/packages/react-native-autoplay/ios/scenes/AutoPlayScene.swift
+++ b/packages/react-native-autoplay/ios/scenes/AutoPlayScene.swift
@@ -106,7 +106,7 @@ class AutoPlayScene: UIResponder {
 
     open func traitCollectionDidChange(traitCollection: UITraitCollection) {
         self.traitCollection = traitCollection
-        self.templateStore.traitCollectionDidChange()
+        TemplateStore.traitCollectionDidChange()
     }
 
     open func safeAreaInsetsDidChange(safeAreaInsets: UIEdgeInsets) {

--- a/packages/react-native-autoplay/ios/scenes/HeadUnitSceneDelegate.swift
+++ b/packages/react-native-autoplay/ios/scenes/HeadUnitSceneDelegate.swift
@@ -20,8 +20,7 @@ class HeadUnitSceneDelegate: AutoPlayScene, CPTemplateApplicationSceneDelegate {
     ) {
         self.window = window
         self.interfaceController = AutoPlayInterfaceController(
-            interfaceController: interfaceController,
-            templateStore: self.templateStore
+            interfaceController: interfaceController
         )
 
         let props: [String: Any] = [
@@ -45,8 +44,10 @@ class HeadUnitSceneDelegate: AutoPlayScene, CPTemplateApplicationSceneDelegate {
     ) {
         HybridAutoPlay.emit(event: .diddisconnect)
         disconnect()
-        
-        let mapTemplate = templateStore.getTemplate(templateId: SceneStore.rootModuleName) as? MapTemplate
+
+        let mapTemplate =
+            TemplateStore.getTemplate(templateId: SceneStore.rootModuleName)
+            as? MapTemplate
         mapTemplate?.stopNavigation()
     }
 

--- a/packages/react-native-autoplay/ios/templates/AutoPlayTemplate.swift
+++ b/packages/react-native-autoplay/ios/templates/AutoPlayTemplate.swift
@@ -10,7 +10,7 @@ import CarPlay
 protocol AutoPlayTemplate {
     var autoDismissMs: Double? { get }
 
-    func invalidate()
+    @MainActor func invalidate()
     func onWillAppear(animated: Bool)
     func onDidAppear(animated: Bool)
     func onWillDisappear(animated: Bool)
@@ -27,9 +27,10 @@ extension AutoPlayTemplate {
 }
 
 protocol AutoPlayHeaderProviding {
-    var barButtons: [NitroAction]? { get set }
+    @MainActor var barButtons: [NitroAction]? { get set }
 }
 
+@MainActor
 func setBarButtons(template: CPTemplate, barButtons: [NitroAction]?) {
     guard let template = template as? CPBarButtonProviding else { return }
 

--- a/packages/react-native-autoplay/ios/templates/GridTemplate.swift
+++ b/packages/react-native-autoplay/ios/templates/GridTemplate.swift
@@ -37,8 +37,6 @@ class GridTemplate: AutoPlayTemplate, AutoPlayHeaderProviding {
             gridButtons: GridTemplate.parseButtons(buttons: config.buttons),
             id: config.id
         )
-
-        setBarButtons(template: template, barButtons: barButtons)
     }
 
     static func parseButtons(buttons: [NitroGridButton]) -> [CPGridButton] {
@@ -104,6 +102,7 @@ class GridTemplate: AutoPlayTemplate, AutoPlayHeaderProviding {
         config.onPopped?()
     }
 
+    @MainActor
     func updateButtons(buttons: [NitroGridButton]) {
         config.buttons = buttons
         invalidate()

--- a/packages/react-native-autoplay/ios/templates/InformationTemplate.swift
+++ b/packages/react-native-autoplay/ios/templates/InformationTemplate.swift
@@ -39,8 +39,6 @@ class InformationTemplate: AutoPlayTemplate, AutoPlayHeaderProviding {
             actions: Parser.parseInformationActions(actions: config.actions),
             id: config.id
         )
-
-        setBarButtons(template: template, barButtons: barButtons)
     }
 
     func invalidate() {
@@ -68,6 +66,7 @@ class InformationTemplate: AutoPlayTemplate, AutoPlayHeaderProviding {
         config.onPopped?()
     }
 
+    @MainActor
     func updateSection(section: NitroSection) {
         config.section = section
         invalidate()

--- a/packages/react-native-autoplay/ios/templates/ListTemplate.swift
+++ b/packages/react-native-autoplay/ios/templates/ListTemplate.swift
@@ -38,10 +38,9 @@ class ListTemplate: AutoPlayTemplate, AutoPlayHeaderProviding {
             assistantCellConfiguration: nil,
             id: config.id
         )
-        
-        invalidate()
     }
 
+    @MainActor
     func invalidate() {
         setBarButtons(template: template, barButtons: barButtons)
 
@@ -74,11 +73,13 @@ class ListTemplate: AutoPlayTemplate, AutoPlayHeaderProviding {
         config.onPopped?()
     }
 
+    @MainActor
     private func updateSection(section: NitroSection, sectionIndex: Int) {
         config.sections?[sectionIndex] = section
         invalidate()
     }
 
+    @MainActor
     func updateSections(sections: [NitroSection]?) {
         config.sections = sections
         invalidate()

--- a/packages/react-native-autoplay/ios/templates/MapTemplate.swift
+++ b/packages/react-native-autoplay/ios/templates/MapTemplate.swift
@@ -182,9 +182,7 @@ class MapTemplate: NSObject, AutoPlayTemplate, AutoPlayHeaderProviding,
 
         template.tripEstimateStyle = isDark ? .dark : .light
 
-        DispatchQueue.main.async {
-            self.invalidate()
-        }
+        invalidate()
     }
 
     // MARK: gestures
@@ -502,9 +500,7 @@ class MapTemplate: NSObject, AutoPlayTemplate, AutoPlayHeaderProviding,
         onTripSelected = nil
         onTripStarted = nil
 
-        DispatchQueue.main.async {
-            self.invalidate()
-        }
+        invalidate()
     }
 
     func mapTemplate(

--- a/packages/react-native-autoplay/ios/templates/MapTemplate.swift
+++ b/packages/react-native-autoplay/ios/templates/MapTemplate.swift
@@ -25,7 +25,7 @@ class MapTemplate: NSObject, AutoPlayTemplate, AutoPlayHeaderProviding,
         }
         set {
             config.headerActions = newValue
-            setBarButtons(template: template, barButtons: newValue)
+            invalidate()
         }
     }
 
@@ -42,14 +42,7 @@ class MapTemplate: NSObject, AutoPlayTemplate, AutoPlayHeaderProviding,
     var navigationSession: CPNavigationSession?
     var navigationAlert: NavigationAlertWrapper?
 
-    var tripSelectorVisible = false {
-        didSet {
-            if !tripSelectorVisible && oldValue {
-                // this makes sure the latest config updates are applied when the trip selector is gone again
-                invalidate()
-            }
-        }
-    }
+    var tripSelectorVisible = false
 
     init(config: MapTemplateConfig) {
         self.config = config
@@ -71,7 +64,6 @@ class MapTemplate: NSObject, AutoPlayTemplate, AutoPlayHeaderProviding,
         super.init()
 
         template.mapDelegate = self
-        invalidate()
     }
 
     func onPanButtonPress() {
@@ -125,12 +117,13 @@ class MapTemplate: NSObject, AutoPlayTemplate, AutoPlayHeaderProviding,
 
     }
 
+    @MainActor
     func invalidate() {
         if tripSelectorVisible {
             // ignore invalidate calls to not break the trip selectors back button
             return
         }
-        
+
         if template.isPanningInterfaceVisible {
             // while panning interface is shown we only provide a back button on the header
             // and all map buttons except the pan button
@@ -141,13 +134,14 @@ class MapTemplate: NSObject, AutoPlayTemplate, AutoPlayHeaderProviding,
             template.backButton = CPBarButton(title: "") { _ in
                 self.template.dismissPanningInterface(animated: true)
             }
-            
-            let mapButtons = config.mapButtons?.filter { button in
-                button.type != .pan
-            } ?? []
-            
+
+            let mapButtons =
+                config.mapButtons?.filter { button in
+                    button.type != .pan
+                } ?? []
+
             template.mapButtons = parseMapButtons(mapButtons: mapButtons)
-            
+
             return
         }
 
@@ -186,9 +180,11 @@ class MapTemplate: NSObject, AutoPlayTemplate, AutoPlayHeaderProviding,
             isDark ? .dark : .light
         )
 
-        invalidate()
-
         template.tripEstimateStyle = isDark ? .dark : .light
+
+        DispatchQueue.main.async {
+            self.invalidate()
+        }
     }
 
     // MARK: gestures
@@ -215,7 +211,7 @@ class MapTemplate: NSObject, AutoPlayTemplate, AutoPlayHeaderProviding,
         if template.isPanningInterfaceVisible {
             return
         }
-        
+
         if scale == 1 && velocity == 1 {
             config.onDoubleClick?(Point(x: center.x, y: center.y))
             return
@@ -243,7 +239,8 @@ class MapTemplate: NSObject, AutoPlayTemplate, AutoPlayHeaderProviding,
     ) {
         let panButtonScrollPercentage = config.panButtonScrollPercentage ?? 0.15
         let scrollDistanceX = screenDimensions.width * panButtonScrollPercentage
-        let scrollDistanceY = screenDimensions.height * panButtonScrollPercentage
+        let scrollDistanceY =
+            screenDimensions.height * panButtonScrollPercentage
 
         var translation = CGPoint.zero
 
@@ -442,8 +439,23 @@ class MapTemplate: NSObject, AutoPlayTemplate, AutoPlayHeaderProviding,
         onBackPressed: @escaping () -> Void,
         mapButtons: [NitroMapButton]
     ) -> TripSelectorCallback {
+        tripSelectorVisible = true
         self.onTripSelected = onTripSelected
         self.onTripStarted = onTripStarted
+
+        DispatchQueue.main.async {
+            self.template.backButton = CPBarButton(title: "") { _ in
+                self.hideTripSelector()
+
+                onBackPressed()
+            }
+
+            self.template.leadingNavigationBarButtons = []
+            self.template.trailingNavigationBarButtons = []
+            self.template.mapButtons = self.parseMapButtons(
+                mapButtons: mapButtons
+            )
+        }
 
         let textConfiguration = Parser.parseTripPreviewTextConfig(
             textConfig: textConfig
@@ -454,22 +466,11 @@ class MapTemplate: NSObject, AutoPlayTemplate, AutoPlayHeaderProviding,
             tripPreviews.first(where: { $0.id == tripId })
         }
 
-        template.backButton = CPBarButton(title: "") { _ in
-            self.hideTripSelector()
-
-            onBackPressed()
-        }
-        template.leadingNavigationBarButtons = []
-        template.trailingNavigationBarButtons = []
-        template.mapButtons = parseMapButtons(mapButtons: mapButtons)
-
         template.showTripPreviews(
             tripPreviews,
             selectedTrip: selectedTrip,
             textConfiguration: textConfiguration
         )
-
-        tripSelectorVisible = true
 
         tripPreviews.forEach { trip in
             guard
@@ -500,6 +501,10 @@ class MapTemplate: NSObject, AutoPlayTemplate, AutoPlayHeaderProviding,
         tripSelectorVisible = false
         onTripSelected = nil
         onTripStarted = nil
+
+        DispatchQueue.main.async {
+            self.invalidate()
+        }
     }
 
     func mapTemplate(

--- a/packages/react-native-autoplay/ios/templates/TemplateStore.swift
+++ b/packages/react-native-autoplay/ios/templates/TemplateStore.swift
@@ -7,27 +7,27 @@
 import CarPlay
 
 class TemplateStore {
-    private var store: [String: AutoPlayTemplate] = [:]
+    private static var store: [String: AutoPlayTemplate] = [:]
 
-    func getCPTemplate(templateId key: String) -> CPTemplate? {
+    static func getCPTemplate(templateId key: String) -> CPTemplate? {
         return store[key]?.getTemplate()
     }
 
-    func getTemplate(templateId: String) -> AutoPlayTemplate? {
+    static func getTemplate(templateId: String) -> AutoPlayTemplate? {
         return store[templateId]
     }
 
-    func addTemplate(template: AutoPlayTemplate, templateId: String) {
+    static func addTemplate(template: AutoPlayTemplate, templateId: String) {
         store[templateId] = template
     }
 
-    func removeTemplate(templateId: String) {
+    static func removeTemplate(templateId: String) {
         store[templateId]?.onPopped()
 
         store.removeValue(forKey: templateId)
     }
 
-    func removeTemplates(templateIds: [String]) {
+    static func removeTemplates(templateIds: [String]) {
         templateIds.forEach { templateId in
             store[templateId]?.onPopped()
         }
@@ -35,11 +35,11 @@ class TemplateStore {
         store = store.filter { !templateIds.contains($0.key) }
     }
 
-    func purge() {
+    static func purge() {
         store = store.filter { !($0.value.getTemplate() is CPSearchTemplate) }
     }
 
-    func traitCollectionDidChange() {
+    static func traitCollectionDidChange() {
         store.values.forEach { template in template.traitCollectionDidChange() }
     }
 }

--- a/packages/react-native-autoplay/ios/utils/RootModule.swift
+++ b/packages/react-native-autoplay/ios/utils/RootModule.swift
@@ -28,23 +28,21 @@ class RootModule {
         templateId: String,
         perform action: @escaping (T) throws -> Void
     ) throws {
-        try withScene { scene in
-            guard
-                let template = scene.templateStore.getTemplate(
-                    templateId: templateId
-                )
-            else {
-                throw AutoPlayError.templateNotFound(templateId)
-            }
-
-            guard let template = template as? T else {
-                throw AutoPlayError.invalidTemplateType(
-                    "\(template) is not a \(T.self) template"
-                )
-            }
-
-            try action(template)
+        guard
+            let template = TemplateStore.getTemplate(
+                templateId: templateId
+            )
+        else {
+            throw AutoPlayError.templateNotFound(templateId)
         }
+
+        guard let template = template as? T else {
+            throw AutoPlayError.invalidTemplateType(
+                "\(template) is not a \(T.self) template"
+            )
+        }
+
+        try action(template)
     }
 
     static func withTemplate<T: CPTemplate>(
@@ -63,7 +61,6 @@ class RootModule {
         }
     }
 
-    @MainActor
     static func withScene<T>(
         perform action:
             @escaping (AutoPlayScene) async throws -> T
@@ -105,30 +102,6 @@ class RootModule {
     ) async throws -> T {
         try await withSceneAndInterfaceController { _, interfaceController in
             try await action(interfaceController)
-        }
-    }
-
-    @MainActor
-    static func withSceneTemplateAndInterfaceController<T>(
-        templateId: String,
-        perform action:
-            @escaping (CPTemplate, AutoPlayScene, AutoPlayInterfaceController)
-            async throws -> T
-    ) async throws -> T {
-        return try await withSceneAndInterfaceController {
-            scene,
-            interfaceController in
-
-            guard
-                let template = scene.templateStore.getCPTemplate(
-                    templateId: templateId
-                )
-            else {
-                throw AutoPlayError.templateNotFound(
-                    "operation failed, \(templateId) template not found"
-                )
-            }
-            return try await action(template, scene, interfaceController)
         }
     }
 }

--- a/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridAutoPlaySpec.cpp
+++ b/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridAutoPlaySpec.cpp
@@ -212,9 +212,9 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
       }
     }();
   }
-  void JHybridAutoPlaySpec::setTemplateHeaderActions(const std::string& templateId, const std::optional<std::vector<NitroAction>>& headerActions) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* templateId */, jni::alias_ref<jni::JArrayClass<JNitroAction>> /* headerActions */)>("setTemplateHeaderActions");
-    method(_javaPart, jni::make_jstring(templateId), headerActions.has_value() ? [&]() {
+  std::shared_ptr<Promise<void>> JHybridAutoPlaySpec::setTemplateHeaderActions(const std::string& templateId, const std::optional<std::vector<NitroAction>>& headerActions) {
+    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* templateId */, jni::alias_ref<jni::JArrayClass<JNitroAction>> /* headerActions */)>("setTemplateHeaderActions");
+    auto __result = method(_javaPart, jni::make_jstring(templateId), headerActions.has_value() ? [&]() {
       size_t __size = headerActions.value().size();
       jni::local_ref<jni::JArrayClass<JNitroAction>> __array = jni::JArrayClass<JNitroAction>::newArray(__size);
       for (size_t __i = 0; __i < __size; __i++) {
@@ -224,6 +224,17 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
       }
       return __array;
     }() : nullptr);
+    return [&]() {
+      auto __promise = Promise<void>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+        __promise->resolve();
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
   bool JHybridAutoPlaySpec::isConnected() {
     static const auto method = javaClassStatic()->getMethod<jboolean()>("isConnected");

--- a/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridAutoPlaySpec.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridAutoPlaySpec.hpp
@@ -62,7 +62,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
     std::shared_ptr<Promise<void>> popToRootTemplate(std::optional<bool> animate) override;
     std::shared_ptr<Promise<void>> popToTemplate(const std::string& templateId, std::optional<bool> animate) override;
     std::function<void()> addSafeAreaInsetsListener(const std::string& moduleName, const std::function<void(const SafeAreaInsets& /* insets */)>& callback) override;
-    void setTemplateHeaderActions(const std::string& templateId, const std::optional<std::vector<NitroAction>>& headerActions) override;
+    std::shared_ptr<Promise<void>> setTemplateHeaderActions(const std::string& templateId, const std::optional<std::vector<NitroAction>>& headerActions) override;
     bool isConnected() override;
 
   private:

--- a/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridGridTemplateSpec.cpp
+++ b/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridGridTemplateSpec.cpp
@@ -38,6 +38,8 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay { struct NitroMapBut
 // Forward declaration of `NitroMapButtonType` to properly resolve imports.
 namespace margelo::nitro::swe::iternio::reactnativeautoplay { enum class NitroMapButtonType; }
 
+#include <NitroModules/Promise.hpp>
+#include <NitroModules/JPromise.hpp>
 #include "GridTemplateConfig.hpp"
 #include "JGridTemplateConfig.hpp"
 #include <string>
@@ -115,9 +117,9 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
     static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JGridTemplateConfig> /* config */)>("createGridTemplate");
     method(_javaPart, JGridTemplateConfig::fromCpp(config));
   }
-  void JHybridGridTemplateSpec::updateGridTemplateButtons(const std::string& templateId, const std::vector<NitroGridButton>& buttons) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* templateId */, jni::alias_ref<jni::JArrayClass<JNitroGridButton>> /* buttons */)>("updateGridTemplateButtons");
-    method(_javaPart, jni::make_jstring(templateId), [&]() {
+  std::shared_ptr<Promise<void>> JHybridGridTemplateSpec::updateGridTemplateButtons(const std::string& templateId, const std::vector<NitroGridButton>& buttons) {
+    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* templateId */, jni::alias_ref<jni::JArrayClass<JNitroGridButton>> /* buttons */)>("updateGridTemplateButtons");
+    auto __result = method(_javaPart, jni::make_jstring(templateId), [&]() {
       size_t __size = buttons.size();
       jni::local_ref<jni::JArrayClass<JNitroGridButton>> __array = jni::JArrayClass<JNitroGridButton>::newArray(__size);
       for (size_t __i = 0; __i < __size; __i++) {
@@ -127,6 +129,17 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
       }
       return __array;
     }());
+    return [&]() {
+      auto __promise = Promise<void>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+        __promise->resolve();
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
 
 } // namespace margelo::nitro::swe::iternio::reactnativeautoplay

--- a/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridGridTemplateSpec.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridGridTemplateSpec.hpp
@@ -55,7 +55,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
   public:
     // Methods
     void createGridTemplate(const GridTemplateConfig& config) override;
-    void updateGridTemplateButtons(const std::string& templateId, const std::vector<NitroGridButton>& buttons) override;
+    std::shared_ptr<Promise<void>> updateGridTemplateButtons(const std::string& templateId, const std::vector<NitroGridButton>& buttons) override;
 
   private:
     friend HybridBase;

--- a/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridInformationTemplateSpec.cpp
+++ b/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridInformationTemplateSpec.cpp
@@ -42,6 +42,8 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay { struct NitroMapBut
 // Forward declaration of `NitroMapButtonType` to properly resolve imports.
 namespace margelo::nitro::swe::iternio::reactnativeautoplay { enum class NitroMapButtonType; }
 
+#include <NitroModules/Promise.hpp>
+#include <NitroModules/JPromise.hpp>
 #include "InformationTemplateConfig.hpp"
 #include "JInformationTemplateConfig.hpp"
 #include <string>
@@ -123,9 +125,20 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
     static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JInformationTemplateConfig> /* config */)>("createInformationTemplate");
     method(_javaPart, JInformationTemplateConfig::fromCpp(config));
   }
-  void JHybridInformationTemplateSpec::updateInformationTemplateSections(const std::string& templateId, const NitroSection& section) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* templateId */, jni::alias_ref<JNitroSection> /* section */)>("updateInformationTemplateSections");
-    method(_javaPart, jni::make_jstring(templateId), JNitroSection::fromCpp(section));
+  std::shared_ptr<Promise<void>> JHybridInformationTemplateSpec::updateInformationTemplateSections(const std::string& templateId, const NitroSection& section) {
+    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* templateId */, jni::alias_ref<JNitroSection> /* section */)>("updateInformationTemplateSections");
+    auto __result = method(_javaPart, jni::make_jstring(templateId), JNitroSection::fromCpp(section));
+    return [&]() {
+      auto __promise = Promise<void>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+        __promise->resolve();
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
 
 } // namespace margelo::nitro::swe::iternio::reactnativeautoplay

--- a/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridInformationTemplateSpec.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridInformationTemplateSpec.hpp
@@ -55,7 +55,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
   public:
     // Methods
     void createInformationTemplate(const InformationTemplateConfig& config) override;
-    void updateInformationTemplateSections(const std::string& templateId, const NitroSection& section) override;
+    std::shared_ptr<Promise<void>> updateInformationTemplateSections(const std::string& templateId, const NitroSection& section) override;
 
   private:
     friend HybridBase;

--- a/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridListTemplateSpec.cpp
+++ b/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridListTemplateSpec.cpp
@@ -42,6 +42,8 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay { struct NitroMapBut
 // Forward declaration of `NitroMapButtonType` to properly resolve imports.
 namespace margelo::nitro::swe::iternio::reactnativeautoplay { enum class NitroMapButtonType; }
 
+#include <NitroModules/Promise.hpp>
+#include <NitroModules/JPromise.hpp>
 #include "ListTemplateConfig.hpp"
 #include "JListTemplateConfig.hpp"
 #include <string>
@@ -123,9 +125,9 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
     static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JListTemplateConfig> /* config */)>("createListTemplate");
     method(_javaPart, JListTemplateConfig::fromCpp(config));
   }
-  void JHybridListTemplateSpec::updateListTemplateSections(const std::string& templateId, const std::optional<std::vector<NitroSection>>& sections) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* templateId */, jni::alias_ref<jni::JArrayClass<JNitroSection>> /* sections */)>("updateListTemplateSections");
-    method(_javaPart, jni::make_jstring(templateId), sections.has_value() ? [&]() {
+  std::shared_ptr<Promise<void>> JHybridListTemplateSpec::updateListTemplateSections(const std::string& templateId, const std::optional<std::vector<NitroSection>>& sections) {
+    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* templateId */, jni::alias_ref<jni::JArrayClass<JNitroSection>> /* sections */)>("updateListTemplateSections");
+    auto __result = method(_javaPart, jni::make_jstring(templateId), sections.has_value() ? [&]() {
       size_t __size = sections.value().size();
       jni::local_ref<jni::JArrayClass<JNitroSection>> __array = jni::JArrayClass<JNitroSection>::newArray(__size);
       for (size_t __i = 0; __i < __size; __i++) {
@@ -135,6 +137,17 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
       }
       return __array;
     }() : nullptr);
+    return [&]() {
+      auto __promise = Promise<void>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+        __promise->resolve();
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
 
 } // namespace margelo::nitro::swe::iternio::reactnativeautoplay

--- a/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridListTemplateSpec.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridListTemplateSpec.hpp
@@ -55,7 +55,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
   public:
     // Methods
     void createListTemplate(const ListTemplateConfig& config) override;
-    void updateListTemplateSections(const std::string& templateId, const std::optional<std::vector<NitroSection>>& sections) override;
+    std::shared_ptr<Promise<void>> updateListTemplateSections(const std::string& templateId, const std::optional<std::vector<NitroSection>>& sections) override;
 
   private:
     friend HybridBase;

--- a/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridMapTemplateSpec.cpp
+++ b/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridMapTemplateSpec.cpp
@@ -97,6 +97,8 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay { struct TripConfig;
 #include <string>
 #include <functional>
 #include "JFunc_void_std__string.hpp"
+#include <NitroModules/Promise.hpp>
+#include <NitroModules/JPromise.hpp>
 #include "MapTemplateConfig.hpp"
 #include "JMapTemplateConfig.hpp"
 #include <optional>
@@ -271,9 +273,9 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
     static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* templateId */)>("hideTripSelector");
     method(_javaPart, jni::make_jstring(templateId));
   }
-  void JHybridMapTemplateSpec::setTemplateMapButtons(const std::string& templateId, const std::optional<std::vector<NitroMapButton>>& buttons) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* templateId */, jni::alias_ref<jni::JArrayClass<JNitroMapButton>> /* buttons */)>("setTemplateMapButtons");
-    method(_javaPart, jni::make_jstring(templateId), buttons.has_value() ? [&]() {
+  std::shared_ptr<Promise<void>> JHybridMapTemplateSpec::setTemplateMapButtons(const std::string& templateId, const std::optional<std::vector<NitroMapButton>>& buttons) {
+    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* templateId */, jni::alias_ref<jni::JArrayClass<JNitroMapButton>> /* buttons */)>("setTemplateMapButtons");
+    auto __result = method(_javaPart, jni::make_jstring(templateId), buttons.has_value() ? [&]() {
       size_t __size = buttons.value().size();
       jni::local_ref<jni::JArrayClass<JNitroMapButton>> __array = jni::JArrayClass<JNitroMapButton>::newArray(__size);
       for (size_t __i = 0; __i < __size; __i++) {
@@ -283,6 +285,17 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
       }
       return __array;
     }() : nullptr);
+    return [&]() {
+      auto __promise = Promise<void>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+        __promise->resolve();
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
   void JHybridMapTemplateSpec::updateVisibleTravelEstimate(const std::string& templateId, VisibleTravelEstimate visibleTravelEstimate) {
     static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* templateId */, jni::alias_ref<JVisibleTravelEstimate> /* visibleTravelEstimate */)>("updateVisibleTravelEstimate");

--- a/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridMapTemplateSpec.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridMapTemplateSpec.hpp
@@ -60,7 +60,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
     void dismissNavigationAlert(const std::string& templateId, double navigationAlertId) override;
     TripSelectorCallback showTripSelector(const std::string& templateId, const std::vector<TripsConfig>& trips, const std::optional<std::string>& selectedTripId, const TripPreviewTextConfiguration& textConfig, const std::function<void(const std::string& /* tripId */, const std::string& /* routeId */)>& onTripSelected, const std::function<void(const std::string& /* tripId */, const std::string& /* routeId */)>& onTripStarted, const std::function<void()>& onBackPressed, const std::vector<NitroMapButton>& mapButtons) override;
     void hideTripSelector(const std::string& templateId) override;
-    void setTemplateMapButtons(const std::string& templateId, const std::optional<std::vector<NitroMapButton>>& buttons) override;
+    std::shared_ptr<Promise<void>> setTemplateMapButtons(const std::string& templateId, const std::optional<std::vector<NitroMapButton>>& buttons) override;
     void updateVisibleTravelEstimate(const std::string& templateId, VisibleTravelEstimate visibleTravelEstimate) override;
     void updateTravelEstimates(const std::string& templateId, const std::vector<TripPoint>& steps) override;
     void updateManeuvers(const std::string& templateId, const std::variant<std::vector<NitroRoutingManeuver>, NitroMessageManeuver>& maneuvers) override;

--- a/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridSearchTemplateSpec.cpp
+++ b/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridSearchTemplateSpec.cpp
@@ -36,6 +36,8 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay { struct NitroRow; }
 // Forward declaration of `NitroSectionType` to properly resolve imports.
 namespace margelo::nitro::swe::iternio::reactnativeautoplay { enum class NitroSectionType; }
 
+#include <NitroModules/Promise.hpp>
+#include <NitroModules/JPromise.hpp>
 #include "SearchTemplateConfig.hpp"
 #include "JSearchTemplateConfig.hpp"
 #include <string>
@@ -110,9 +112,20 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
     static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JSearchTemplateConfig> /* config */)>("createSearchTemplate");
     method(_javaPart, JSearchTemplateConfig::fromCpp(config));
   }
-  void JHybridSearchTemplateSpec::updateSearchResults(const std::string& templateId, const NitroSection& results) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* templateId */, jni::alias_ref<JNitroSection> /* results */)>("updateSearchResults");
-    method(_javaPart, jni::make_jstring(templateId), JNitroSection::fromCpp(results));
+  std::shared_ptr<Promise<void>> JHybridSearchTemplateSpec::updateSearchResults(const std::string& templateId, const NitroSection& results) {
+    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* templateId */, jni::alias_ref<JNitroSection> /* results */)>("updateSearchResults");
+    auto __result = method(_javaPart, jni::make_jstring(templateId), JNitroSection::fromCpp(results));
+    return [&]() {
+      auto __promise = Promise<void>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+        __promise->resolve();
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
 
 } // namespace margelo::nitro::swe::iternio::reactnativeautoplay

--- a/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridSearchTemplateSpec.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridSearchTemplateSpec.hpp
@@ -55,7 +55,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
   public:
     // Methods
     void createSearchTemplate(const SearchTemplateConfig& config) override;
-    void updateSearchResults(const std::string& templateId, const NitroSection& results) override;
+    std::shared_ptr<Promise<void>> updateSearchResults(const std::string& templateId, const NitroSection& results) override;
 
   private:
     friend HybridBase;

--- a/packages/react-native-autoplay/nitrogen/generated/android/kotlin/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridAutoPlaySpec.kt
+++ b/packages/react-native-autoplay/nitrogen/generated/android/kotlin/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridAutoPlaySpec.kt
@@ -95,7 +95,7 @@ abstract class HybridAutoPlaySpec: HybridObject() {
   
   @DoNotStrip
   @Keep
-  abstract fun setTemplateHeaderActions(templateId: String, headerActions: Array<NitroAction>?): Unit
+  abstract fun setTemplateHeaderActions(templateId: String, headerActions: Array<NitroAction>?): Promise<Unit>
   
   @DoNotStrip
   @Keep

--- a/packages/react-native-autoplay/nitrogen/generated/android/kotlin/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridGridTemplateSpec.kt
+++ b/packages/react-native-autoplay/nitrogen/generated/android/kotlin/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridGridTemplateSpec.kt
@@ -10,6 +10,7 @@ package com.margelo.nitro.swe.iternio.reactnativeautoplay
 import androidx.annotation.Keep
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import com.margelo.nitro.core.Promise
 import com.margelo.nitro.core.HybridObject
 
 /**
@@ -51,7 +52,7 @@ abstract class HybridGridTemplateSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
-  abstract fun updateGridTemplateButtons(templateId: String, buttons: Array<NitroGridButton>): Unit
+  abstract fun updateGridTemplateButtons(templateId: String, buttons: Array<NitroGridButton>): Promise<Unit>
 
   private external fun initHybrid(): HybridData
 

--- a/packages/react-native-autoplay/nitrogen/generated/android/kotlin/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridInformationTemplateSpec.kt
+++ b/packages/react-native-autoplay/nitrogen/generated/android/kotlin/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridInformationTemplateSpec.kt
@@ -10,6 +10,7 @@ package com.margelo.nitro.swe.iternio.reactnativeautoplay
 import androidx.annotation.Keep
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import com.margelo.nitro.core.Promise
 import com.margelo.nitro.core.HybridObject
 
 /**
@@ -51,7 +52,7 @@ abstract class HybridInformationTemplateSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
-  abstract fun updateInformationTemplateSections(templateId: String, section: NitroSection): Unit
+  abstract fun updateInformationTemplateSections(templateId: String, section: NitroSection): Promise<Unit>
 
   private external fun initHybrid(): HybridData
 

--- a/packages/react-native-autoplay/nitrogen/generated/android/kotlin/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridListTemplateSpec.kt
+++ b/packages/react-native-autoplay/nitrogen/generated/android/kotlin/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridListTemplateSpec.kt
@@ -10,6 +10,7 @@ package com.margelo.nitro.swe.iternio.reactnativeautoplay
 import androidx.annotation.Keep
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import com.margelo.nitro.core.Promise
 import com.margelo.nitro.core.HybridObject
 
 /**
@@ -51,7 +52,7 @@ abstract class HybridListTemplateSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
-  abstract fun updateListTemplateSections(templateId: String, sections: Array<NitroSection>?): Unit
+  abstract fun updateListTemplateSections(templateId: String, sections: Array<NitroSection>?): Promise<Unit>
 
   private external fun initHybrid(): HybridData
 

--- a/packages/react-native-autoplay/nitrogen/generated/android/kotlin/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridMapTemplateSpec.kt
+++ b/packages/react-native-autoplay/nitrogen/generated/android/kotlin/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridMapTemplateSpec.kt
@@ -10,6 +10,7 @@ package com.margelo.nitro.swe.iternio.reactnativeautoplay
 import androidx.annotation.Keep
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import com.margelo.nitro.core.Promise
 import com.margelo.nitro.core.HybridObject
 
 /**
@@ -76,7 +77,7 @@ abstract class HybridMapTemplateSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
-  abstract fun setTemplateMapButtons(templateId: String, buttons: Array<NitroMapButton>?): Unit
+  abstract fun setTemplateMapButtons(templateId: String, buttons: Array<NitroMapButton>?): Promise<Unit>
   
   @DoNotStrip
   @Keep

--- a/packages/react-native-autoplay/nitrogen/generated/android/kotlin/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridSearchTemplateSpec.kt
+++ b/packages/react-native-autoplay/nitrogen/generated/android/kotlin/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridSearchTemplateSpec.kt
@@ -10,6 +10,7 @@ package com.margelo.nitro.swe.iternio.reactnativeautoplay
 import androidx.annotation.Keep
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import com.margelo.nitro.core.Promise
 import com.margelo.nitro.core.HybridObject
 
 /**
@@ -51,7 +52,7 @@ abstract class HybridSearchTemplateSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
-  abstract fun updateSearchResults(templateId: String, results: NitroSection): Unit
+  abstract fun updateSearchResults(templateId: String, results: NitroSection): Promise<Unit>
 
   private external fun initHybrid(): HybridData
 

--- a/packages/react-native-autoplay/nitrogen/generated/ios/ReactNativeAutoPlay-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/ReactNativeAutoPlay-Swift-Cxx-Bridge.hpp
@@ -505,15 +505,6 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay::bridge::swift {
     return Result<std::shared_ptr<Promise<void>>>::withError(error);
   }
   
-  // pragma MARK: Result<void>
-  using Result_void_ = Result<void>;
-  inline Result_void_ create_Result_void_() noexcept {
-    return Result<void>::withValue();
-  }
-  inline Result_void_ create_Result_void_(const std::exception_ptr& error) noexcept {
-    return Result<void>::withError(error);
-  }
-  
   // pragma MARK: Result<bool>
   using Result_bool_ = Result<bool>;
   inline Result_bool_ create_Result_bool_(bool value) noexcept {
@@ -578,6 +569,15 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay::bridge::swift {
   // pragma MARK: std::weak_ptr<HybridCarPlayDashboardSpec>
   using std__weak_ptr_HybridCarPlayDashboardSpec_ = std::weak_ptr<HybridCarPlayDashboardSpec>;
   inline std__weak_ptr_HybridCarPlayDashboardSpec_ weakify_std__shared_ptr_HybridCarPlayDashboardSpec_(const std::shared_ptr<HybridCarPlayDashboardSpec>& strong) noexcept { return strong; }
+  
+  // pragma MARK: Result<void>
+  using Result_void_ = Result<void>;
+  inline Result_void_ create_Result_void_() noexcept {
+    return Result<void>::withValue();
+  }
+  inline Result_void_ create_Result_void_(const std::exception_ptr& error) noexcept {
+    return Result<void>::withError(error);
+  }
   
   // pragma MARK: std::function<void(const std::string& /* clusterId */)>
   /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/c++/HybridAutoPlaySpecSwift.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/c++/HybridAutoPlaySpecSwift.hpp
@@ -158,11 +158,13 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
       auto __value = std::move(__result.value());
       return __value;
     }
-    inline void setTemplateHeaderActions(const std::string& templateId, const std::optional<std::vector<NitroAction>>& headerActions) override {
+    inline std::shared_ptr<Promise<void>> setTemplateHeaderActions(const std::string& templateId, const std::optional<std::vector<NitroAction>>& headerActions) override {
       auto __result = _swiftPart.setTemplateHeaderActions(templateId, headerActions);
       if (__result.hasError()) [[unlikely]] {
         std::rethrow_exception(__result.error());
       }
+      auto __value = std::move(__result.value());
+      return __value;
     }
     inline bool isConnected() override {
       auto __result = _swiftPart.isConnected();

--- a/packages/react-native-autoplay/nitrogen/generated/ios/c++/HybridGridTemplateSpecSwift.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/c++/HybridGridTemplateSpecSwift.hpp
@@ -63,6 +63,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay { enum class NitroMa
 #include "NitroBaseMapTemplateConfig.hpp"
 #include "NitroMapButton.hpp"
 #include "NitroMapButtonType.hpp"
+#include <NitroModules/Promise.hpp>
 
 #include "ReactNativeAutoPlay-Swift-Cxx-Umbrella.hpp"
 
@@ -114,11 +115,13 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
         std::rethrow_exception(__result.error());
       }
     }
-    inline void updateGridTemplateButtons(const std::string& templateId, const std::vector<NitroGridButton>& buttons) override {
+    inline std::shared_ptr<Promise<void>> updateGridTemplateButtons(const std::string& templateId, const std::vector<NitroGridButton>& buttons) override {
       auto __result = _swiftPart.updateGridTemplateButtons(templateId, buttons);
       if (__result.hasError()) [[unlikely]] {
         std::rethrow_exception(__result.error());
       }
+      auto __value = std::move(__result.value());
+      return __value;
     }
 
   private:

--- a/packages/react-native-autoplay/nitrogen/generated/ios/c++/HybridInformationTemplateSpecSwift.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/c++/HybridInformationTemplateSpecSwift.hpp
@@ -69,6 +69,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay { enum class NitroMa
 #include "NitroBaseMapTemplateConfig.hpp"
 #include "NitroMapButton.hpp"
 #include "NitroMapButtonType.hpp"
+#include <NitroModules/Promise.hpp>
 
 #include "ReactNativeAutoPlay-Swift-Cxx-Umbrella.hpp"
 
@@ -120,11 +121,13 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
         std::rethrow_exception(__result.error());
       }
     }
-    inline void updateInformationTemplateSections(const std::string& templateId, const NitroSection& section) override {
+    inline std::shared_ptr<Promise<void>> updateInformationTemplateSections(const std::string& templateId, const NitroSection& section) override {
       auto __result = _swiftPart.updateInformationTemplateSections(templateId, std::forward<decltype(section)>(section));
       if (__result.hasError()) [[unlikely]] {
         std::rethrow_exception(__result.error());
       }
+      auto __value = std::move(__result.value());
+      return __value;
     }
 
   private:

--- a/packages/react-native-autoplay/nitrogen/generated/ios/c++/HybridListTemplateSpecSwift.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/c++/HybridListTemplateSpecSwift.hpp
@@ -69,6 +69,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay { enum class NitroMa
 #include "NitroBaseMapTemplateConfig.hpp"
 #include "NitroMapButton.hpp"
 #include "NitroMapButtonType.hpp"
+#include <NitroModules/Promise.hpp>
 
 #include "ReactNativeAutoPlay-Swift-Cxx-Umbrella.hpp"
 
@@ -120,11 +121,13 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
         std::rethrow_exception(__result.error());
       }
     }
-    inline void updateListTemplateSections(const std::string& templateId, const std::optional<std::vector<NitroSection>>& sections) override {
+    inline std::shared_ptr<Promise<void>> updateListTemplateSections(const std::string& templateId, const std::optional<std::vector<NitroSection>>& sections) override {
       auto __result = _swiftPart.updateListTemplateSections(templateId, sections);
       if (__result.hasError()) [[unlikely]] {
         std::rethrow_exception(__result.error());
       }
+      auto __value = std::move(__result.value());
+      return __value;
     }
 
   private:

--- a/packages/react-native-autoplay/nitrogen/generated/ios/c++/HybridMapTemplateSpecSwift.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/c++/HybridMapTemplateSpecSwift.hpp
@@ -129,6 +129,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay { struct TripConfig;
 #include "TravelEstimates.hpp"
 #include "DurationWithTimeZone.hpp"
 #include "TripPreviewTextConfiguration.hpp"
+#include <NitroModules/Promise.hpp>
 #include "NitroRoutingManeuver.hpp"
 #include "NitroMessageManeuver.hpp"
 #include "NitroAttributedString.hpp"
@@ -227,11 +228,13 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
         std::rethrow_exception(__result.error());
       }
     }
-    inline void setTemplateMapButtons(const std::string& templateId, const std::optional<std::vector<NitroMapButton>>& buttons) override {
+    inline std::shared_ptr<Promise<void>> setTemplateMapButtons(const std::string& templateId, const std::optional<std::vector<NitroMapButton>>& buttons) override {
       auto __result = _swiftPart.setTemplateMapButtons(templateId, buttons);
       if (__result.hasError()) [[unlikely]] {
         std::rethrow_exception(__result.error());
       }
+      auto __value = std::move(__result.value());
+      return __value;
     }
     inline void updateVisibleTravelEstimate(const std::string& templateId, VisibleTravelEstimate visibleTravelEstimate) override {
       auto __result = _swiftPart.updateVisibleTravelEstimate(templateId, static_cast<int>(visibleTravelEstimate));

--- a/packages/react-native-autoplay/nitrogen/generated/ios/c++/HybridSearchTemplateSpecSwift.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/c++/HybridSearchTemplateSpecSwift.hpp
@@ -60,6 +60,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay { enum class NitroSe
 #include "NitroSection.hpp"
 #include "NitroRow.hpp"
 #include "NitroSectionType.hpp"
+#include <NitroModules/Promise.hpp>
 
 #include "ReactNativeAutoPlay-Swift-Cxx-Umbrella.hpp"
 
@@ -111,11 +112,13 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
         std::rethrow_exception(__result.error());
       }
     }
-    inline void updateSearchResults(const std::string& templateId, const NitroSection& results) override {
+    inline std::shared_ptr<Promise<void>> updateSearchResults(const std::string& templateId, const NitroSection& results) override {
       auto __result = _swiftPart.updateSearchResults(templateId, std::forward<decltype(results)>(results));
       if (__result.hasError()) [[unlikely]] {
         std::rethrow_exception(__result.error());
       }
+      auto __value = std::move(__result.value());
+      return __value;
     }
 
   private:

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridAutoPlaySpec.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridAutoPlaySpec.swift
@@ -23,7 +23,7 @@ public protocol HybridAutoPlaySpec_protocol: HybridObject {
   func popToRootTemplate(animate: Bool?) throws -> Promise<Void>
   func popToTemplate(templateId: String, animate: Bool?) throws -> Promise<Void>
   func addSafeAreaInsetsListener(moduleName: String, callback: @escaping (_ insets: SafeAreaInsets) -> Void) throws -> () -> Void
-  func setTemplateHeaderActions(templateId: String, headerActions: [NitroAction]?) throws -> Void
+  func setTemplateHeaderActions(templateId: String, headerActions: [NitroAction]?) throws -> Promise<Void>
   func isConnected() throws -> Bool
 }
 

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridAutoPlaySpec_cxx.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridAutoPlaySpec_cxx.swift
@@ -295,9 +295,9 @@ open class HybridAutoPlaySpec_cxx {
   }
   
   @inline(__always)
-  public final func setTemplateHeaderActions(templateId: std.string, headerActions: bridge.std__optional_std__vector_NitroAction__) -> bridge.Result_void_ {
+  public final func setTemplateHeaderActions(templateId: std.string, headerActions: bridge.std__optional_std__vector_NitroAction__) -> bridge.Result_std__shared_ptr_Promise_void___ {
     do {
-      try self.__implementation.setTemplateHeaderActions(templateId: String(templateId), headerActions: { () -> [NitroAction]? in
+      let __result = try self.__implementation.setTemplateHeaderActions(templateId: String(templateId), headerActions: { () -> [NitroAction]? in
         if bridge.has_value_std__optional_std__vector_NitroAction__(headerActions) {
           let __unwrapped = bridge.get_std__optional_std__vector_NitroAction__(headerActions)
           return __unwrapped.map({ __item in __item })
@@ -305,10 +305,18 @@ open class HybridAutoPlaySpec_cxx {
           return nil
         }
       }())
-      return bridge.create_Result_void_()
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_void__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_void__()
+        let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_void__(__promise)
+        __result
+          .then({ __result in __promiseHolder.resolve() })
+          .catch({ __error in __promiseHolder.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__resultCpp)
     } catch (let __error) {
       let __exceptionPtr = __error.toCpp()
-      return bridge.create_Result_void_(__exceptionPtr)
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__exceptionPtr)
     }
   }
   

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridGridTemplateSpec.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridGridTemplateSpec.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import NitroModules
+import NitroModules
 
 /// See ``HybridGridTemplateSpec``
 public protocol HybridGridTemplateSpec_protocol: HybridObject {
@@ -15,7 +16,7 @@ public protocol HybridGridTemplateSpec_protocol: HybridObject {
 
   // Methods
   func createGridTemplate(config: GridTemplateConfig) throws -> Void
-  func updateGridTemplateButtons(templateId: String, buttons: [NitroGridButton]) throws -> Void
+  func updateGridTemplateButtons(templateId: String, buttons: [NitroGridButton]) throws -> Promise<Void>
 }
 
 public extension HybridGridTemplateSpec_protocol {

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridGridTemplateSpec_cxx.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridGridTemplateSpec_cxx.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import NitroModules
+import NitroModules
 
 /**
  * A class implementation that bridges HybridGridTemplateSpec over to C++.
@@ -129,13 +130,21 @@ open class HybridGridTemplateSpec_cxx {
   }
   
   @inline(__always)
-  public final func updateGridTemplateButtons(templateId: std.string, buttons: bridge.std__vector_NitroGridButton_) -> bridge.Result_void_ {
+  public final func updateGridTemplateButtons(templateId: std.string, buttons: bridge.std__vector_NitroGridButton_) -> bridge.Result_std__shared_ptr_Promise_void___ {
     do {
-      try self.__implementation.updateGridTemplateButtons(templateId: String(templateId), buttons: buttons.map({ __item in __item }))
-      return bridge.create_Result_void_()
+      let __result = try self.__implementation.updateGridTemplateButtons(templateId: String(templateId), buttons: buttons.map({ __item in __item }))
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_void__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_void__()
+        let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_void__(__promise)
+        __result
+          .then({ __result in __promiseHolder.resolve() })
+          .catch({ __error in __promiseHolder.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__resultCpp)
     } catch (let __error) {
       let __exceptionPtr = __error.toCpp()
-      return bridge.create_Result_void_(__exceptionPtr)
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__exceptionPtr)
     }
   }
 }

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridInformationTemplateSpec.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridInformationTemplateSpec.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import NitroModules
+import NitroModules
 
 /// See ``HybridInformationTemplateSpec``
 public protocol HybridInformationTemplateSpec_protocol: HybridObject {
@@ -15,7 +16,7 @@ public protocol HybridInformationTemplateSpec_protocol: HybridObject {
 
   // Methods
   func createInformationTemplate(config: InformationTemplateConfig) throws -> Void
-  func updateInformationTemplateSections(templateId: String, section: NitroSection) throws -> Void
+  func updateInformationTemplateSections(templateId: String, section: NitroSection) throws -> Promise<Void>
 }
 
 public extension HybridInformationTemplateSpec_protocol {

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridInformationTemplateSpec_cxx.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridInformationTemplateSpec_cxx.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import NitroModules
+import NitroModules
 
 /**
  * A class implementation that bridges HybridInformationTemplateSpec over to C++.
@@ -129,13 +130,21 @@ open class HybridInformationTemplateSpec_cxx {
   }
   
   @inline(__always)
-  public final func updateInformationTemplateSections(templateId: std.string, section: NitroSection) -> bridge.Result_void_ {
+  public final func updateInformationTemplateSections(templateId: std.string, section: NitroSection) -> bridge.Result_std__shared_ptr_Promise_void___ {
     do {
-      try self.__implementation.updateInformationTemplateSections(templateId: String(templateId), section: section)
-      return bridge.create_Result_void_()
+      let __result = try self.__implementation.updateInformationTemplateSections(templateId: String(templateId), section: section)
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_void__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_void__()
+        let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_void__(__promise)
+        __result
+          .then({ __result in __promiseHolder.resolve() })
+          .catch({ __error in __promiseHolder.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__resultCpp)
     } catch (let __error) {
       let __exceptionPtr = __error.toCpp()
-      return bridge.create_Result_void_(__exceptionPtr)
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__exceptionPtr)
     }
   }
 }

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridListTemplateSpec.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridListTemplateSpec.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import NitroModules
+import NitroModules
 
 /// See ``HybridListTemplateSpec``
 public protocol HybridListTemplateSpec_protocol: HybridObject {
@@ -15,7 +16,7 @@ public protocol HybridListTemplateSpec_protocol: HybridObject {
 
   // Methods
   func createListTemplate(config: ListTemplateConfig) throws -> Void
-  func updateListTemplateSections(templateId: String, sections: [NitroSection]?) throws -> Void
+  func updateListTemplateSections(templateId: String, sections: [NitroSection]?) throws -> Promise<Void>
 }
 
 public extension HybridListTemplateSpec_protocol {

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridListTemplateSpec_cxx.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridListTemplateSpec_cxx.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import NitroModules
+import NitroModules
 
 /**
  * A class implementation that bridges HybridListTemplateSpec over to C++.
@@ -129,9 +130,9 @@ open class HybridListTemplateSpec_cxx {
   }
   
   @inline(__always)
-  public final func updateListTemplateSections(templateId: std.string, sections: bridge.std__optional_std__vector_NitroSection__) -> bridge.Result_void_ {
+  public final func updateListTemplateSections(templateId: std.string, sections: bridge.std__optional_std__vector_NitroSection__) -> bridge.Result_std__shared_ptr_Promise_void___ {
     do {
-      try self.__implementation.updateListTemplateSections(templateId: String(templateId), sections: { () -> [NitroSection]? in
+      let __result = try self.__implementation.updateListTemplateSections(templateId: String(templateId), sections: { () -> [NitroSection]? in
         if bridge.has_value_std__optional_std__vector_NitroSection__(sections) {
           let __unwrapped = bridge.get_std__optional_std__vector_NitroSection__(sections)
           return __unwrapped.map({ __item in __item })
@@ -139,10 +140,18 @@ open class HybridListTemplateSpec_cxx {
           return nil
         }
       }())
-      return bridge.create_Result_void_()
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_void__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_void__()
+        let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_void__(__promise)
+        __result
+          .then({ __result in __promiseHolder.resolve() })
+          .catch({ __error in __promiseHolder.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__resultCpp)
     } catch (let __error) {
       let __exceptionPtr = __error.toCpp()
-      return bridge.create_Result_void_(__exceptionPtr)
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__exceptionPtr)
     }
   }
 }

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridMapTemplateSpec.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridMapTemplateSpec.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import NitroModules
+import NitroModules
 
 /// See ``HybridMapTemplateSpec``
 public protocol HybridMapTemplateSpec_protocol: HybridObject {
@@ -20,7 +21,7 @@ public protocol HybridMapTemplateSpec_protocol: HybridObject {
   func dismissNavigationAlert(templateId: String, navigationAlertId: Double) throws -> Void
   func showTripSelector(templateId: String, trips: [TripsConfig], selectedTripId: String?, textConfig: TripPreviewTextConfiguration, onTripSelected: @escaping (_ tripId: String, _ routeId: String) -> Void, onTripStarted: @escaping (_ tripId: String, _ routeId: String) -> Void, onBackPressed: @escaping () -> Void, mapButtons: [NitroMapButton]) throws -> TripSelectorCallback
   func hideTripSelector(templateId: String) throws -> Void
-  func setTemplateMapButtons(templateId: String, buttons: [NitroMapButton]?) throws -> Void
+  func setTemplateMapButtons(templateId: String, buttons: [NitroMapButton]?) throws -> Promise<Void>
   func updateVisibleTravelEstimate(templateId: String, visibleTravelEstimate: VisibleTravelEstimate) throws -> Void
   func updateTravelEstimates(templateId: String, steps: [TripPoint]) throws -> Void
   func updateManeuvers(templateId: String, maneuvers: NitroManeuver) throws -> Void

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridMapTemplateSpec_cxx.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridMapTemplateSpec_cxx.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import NitroModules
+import NitroModules
 
 /**
  * A class implementation that bridges HybridMapTemplateSpec over to C++.
@@ -207,9 +208,9 @@ open class HybridMapTemplateSpec_cxx {
   }
   
   @inline(__always)
-  public final func setTemplateMapButtons(templateId: std.string, buttons: bridge.std__optional_std__vector_NitroMapButton__) -> bridge.Result_void_ {
+  public final func setTemplateMapButtons(templateId: std.string, buttons: bridge.std__optional_std__vector_NitroMapButton__) -> bridge.Result_std__shared_ptr_Promise_void___ {
     do {
-      try self.__implementation.setTemplateMapButtons(templateId: String(templateId), buttons: { () -> [NitroMapButton]? in
+      let __result = try self.__implementation.setTemplateMapButtons(templateId: String(templateId), buttons: { () -> [NitroMapButton]? in
         if bridge.has_value_std__optional_std__vector_NitroMapButton__(buttons) {
           let __unwrapped = bridge.get_std__optional_std__vector_NitroMapButton__(buttons)
           return __unwrapped.map({ __item in __item })
@@ -217,10 +218,18 @@ open class HybridMapTemplateSpec_cxx {
           return nil
         }
       }())
-      return bridge.create_Result_void_()
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_void__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_void__()
+        let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_void__(__promise)
+        __result
+          .then({ __result in __promiseHolder.resolve() })
+          .catch({ __error in __promiseHolder.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__resultCpp)
     } catch (let __error) {
       let __exceptionPtr = __error.toCpp()
-      return bridge.create_Result_void_(__exceptionPtr)
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__exceptionPtr)
     }
   }
   

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridSearchTemplateSpec.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridSearchTemplateSpec.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import NitroModules
+import NitroModules
 
 /// See ``HybridSearchTemplateSpec``
 public protocol HybridSearchTemplateSpec_protocol: HybridObject {
@@ -15,7 +16,7 @@ public protocol HybridSearchTemplateSpec_protocol: HybridObject {
 
   // Methods
   func createSearchTemplate(config: SearchTemplateConfig) throws -> Void
-  func updateSearchResults(templateId: String, results: NitroSection) throws -> Void
+  func updateSearchResults(templateId: String, results: NitroSection) throws -> Promise<Void>
 }
 
 public extension HybridSearchTemplateSpec_protocol {

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridSearchTemplateSpec_cxx.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridSearchTemplateSpec_cxx.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import NitroModules
+import NitroModules
 
 /**
  * A class implementation that bridges HybridSearchTemplateSpec over to C++.
@@ -129,13 +130,21 @@ open class HybridSearchTemplateSpec_cxx {
   }
   
   @inline(__always)
-  public final func updateSearchResults(templateId: std.string, results: NitroSection) -> bridge.Result_void_ {
+  public final func updateSearchResults(templateId: std.string, results: NitroSection) -> bridge.Result_std__shared_ptr_Promise_void___ {
     do {
-      try self.__implementation.updateSearchResults(templateId: String(templateId), results: results)
-      return bridge.create_Result_void_()
+      let __result = try self.__implementation.updateSearchResults(templateId: String(templateId), results: results)
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_void__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_void__()
+        let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_void__(__promise)
+        __result
+          .then({ __result in __promiseHolder.resolve() })
+          .catch({ __error in __promiseHolder.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__resultCpp)
     } catch (let __error) {
       let __exceptionPtr = __error.toCpp()
-      return bridge.create_Result_void_(__exceptionPtr)
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__exceptionPtr)
     }
   }
 }

--- a/packages/react-native-autoplay/nitrogen/generated/shared/c++/HybridAutoPlaySpec.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/shared/c++/HybridAutoPlaySpec.hpp
@@ -71,7 +71,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
       virtual std::shared_ptr<Promise<void>> popToRootTemplate(std::optional<bool> animate) = 0;
       virtual std::shared_ptr<Promise<void>> popToTemplate(const std::string& templateId, std::optional<bool> animate) = 0;
       virtual std::function<void()> addSafeAreaInsetsListener(const std::string& moduleName, const std::function<void(const SafeAreaInsets& /* insets */)>& callback) = 0;
-      virtual void setTemplateHeaderActions(const std::string& templateId, const std::optional<std::vector<NitroAction>>& headerActions) = 0;
+      virtual std::shared_ptr<Promise<void>> setTemplateHeaderActions(const std::string& templateId, const std::optional<std::vector<NitroAction>>& headerActions) = 0;
       virtual bool isConnected() = 0;
 
     protected:

--- a/packages/react-native-autoplay/nitrogen/generated/shared/c++/HybridGridTemplateSpec.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/shared/c++/HybridGridTemplateSpec.hpp
@@ -19,6 +19,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay { struct GridTemplat
 namespace margelo::nitro::swe::iternio::reactnativeautoplay { struct NitroGridButton; }
 
 #include "GridTemplateConfig.hpp"
+#include <NitroModules/Promise.hpp>
 #include <string>
 #include "NitroGridButton.hpp"
 #include <vector>
@@ -55,7 +56,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
     public:
       // Methods
       virtual void createGridTemplate(const GridTemplateConfig& config) = 0;
-      virtual void updateGridTemplateButtons(const std::string& templateId, const std::vector<NitroGridButton>& buttons) = 0;
+      virtual std::shared_ptr<Promise<void>> updateGridTemplateButtons(const std::string& templateId, const std::vector<NitroGridButton>& buttons) = 0;
 
     protected:
       // Hybrid Setup

--- a/packages/react-native-autoplay/nitrogen/generated/shared/c++/HybridInformationTemplateSpec.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/shared/c++/HybridInformationTemplateSpec.hpp
@@ -19,6 +19,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay { struct Information
 namespace margelo::nitro::swe::iternio::reactnativeautoplay { struct NitroSection; }
 
 #include "InformationTemplateConfig.hpp"
+#include <NitroModules/Promise.hpp>
 #include <string>
 #include "NitroSection.hpp"
 
@@ -54,7 +55,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
     public:
       // Methods
       virtual void createInformationTemplate(const InformationTemplateConfig& config) = 0;
-      virtual void updateInformationTemplateSections(const std::string& templateId, const NitroSection& section) = 0;
+      virtual std::shared_ptr<Promise<void>> updateInformationTemplateSections(const std::string& templateId, const NitroSection& section) = 0;
 
     protected:
       // Hybrid Setup

--- a/packages/react-native-autoplay/nitrogen/generated/shared/c++/HybridListTemplateSpec.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/shared/c++/HybridListTemplateSpec.hpp
@@ -19,6 +19,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay { struct ListTemplat
 namespace margelo::nitro::swe::iternio::reactnativeautoplay { struct NitroSection; }
 
 #include "ListTemplateConfig.hpp"
+#include <NitroModules/Promise.hpp>
 #include <string>
 #include "NitroSection.hpp"
 #include <vector>
@@ -56,7 +57,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
     public:
       // Methods
       virtual void createListTemplate(const ListTemplateConfig& config) = 0;
-      virtual void updateListTemplateSections(const std::string& templateId, const std::optional<std::vector<NitroSection>>& sections) = 0;
+      virtual std::shared_ptr<Promise<void>> updateListTemplateSections(const std::string& templateId, const std::optional<std::vector<NitroSection>>& sections) = 0;
 
     protected:
       // Hybrid Setup

--- a/packages/react-native-autoplay/nitrogen/generated/shared/c++/HybridMapTemplateSpec.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/shared/c++/HybridMapTemplateSpec.hpp
@@ -49,6 +49,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay { struct TripConfig;
 #include "TripPreviewTextConfiguration.hpp"
 #include <functional>
 #include "NitroMapButton.hpp"
+#include <NitroModules/Promise.hpp>
 #include "VisibleTravelEstimate.hpp"
 #include "TripPoint.hpp"
 #include "NitroRoutingManeuver.hpp"
@@ -93,7 +94,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
       virtual void dismissNavigationAlert(const std::string& templateId, double navigationAlertId) = 0;
       virtual TripSelectorCallback showTripSelector(const std::string& templateId, const std::vector<TripsConfig>& trips, const std::optional<std::string>& selectedTripId, const TripPreviewTextConfiguration& textConfig, const std::function<void(const std::string& /* tripId */, const std::string& /* routeId */)>& onTripSelected, const std::function<void(const std::string& /* tripId */, const std::string& /* routeId */)>& onTripStarted, const std::function<void()>& onBackPressed, const std::vector<NitroMapButton>& mapButtons) = 0;
       virtual void hideTripSelector(const std::string& templateId) = 0;
-      virtual void setTemplateMapButtons(const std::string& templateId, const std::optional<std::vector<NitroMapButton>>& buttons) = 0;
+      virtual std::shared_ptr<Promise<void>> setTemplateMapButtons(const std::string& templateId, const std::optional<std::vector<NitroMapButton>>& buttons) = 0;
       virtual void updateVisibleTravelEstimate(const std::string& templateId, VisibleTravelEstimate visibleTravelEstimate) = 0;
       virtual void updateTravelEstimates(const std::string& templateId, const std::vector<TripPoint>& steps) = 0;
       virtual void updateManeuvers(const std::string& templateId, const std::variant<std::vector<NitroRoutingManeuver>, NitroMessageManeuver>& maneuvers) = 0;

--- a/packages/react-native-autoplay/nitrogen/generated/shared/c++/HybridSearchTemplateSpec.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/shared/c++/HybridSearchTemplateSpec.hpp
@@ -19,6 +19,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay { struct SearchTempl
 namespace margelo::nitro::swe::iternio::reactnativeautoplay { struct NitroSection; }
 
 #include "SearchTemplateConfig.hpp"
+#include <NitroModules/Promise.hpp>
 #include <string>
 #include "NitroSection.hpp"
 
@@ -54,7 +55,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
     public:
       // Methods
       virtual void createSearchTemplate(const SearchTemplateConfig& config) = 0;
-      virtual void updateSearchResults(const std::string& templateId, const NitroSection& results) = 0;
+      virtual std::shared_ptr<Promise<void>> updateSearchResults(const std::string& templateId, const NitroSection& results) = 0;
 
     protected:
       // Hybrid Setup

--- a/packages/react-native-autoplay/package.json
+++ b/packages/react-native-autoplay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iternio/react-native-auto-play",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Android Auto and Apple CarPlay for react-native",
   "main": "lib/index",
   "module": "lib/index",

--- a/packages/react-native-autoplay/src/specs/AutoPlay.nitro.ts
+++ b/packages/react-native-autoplay/src/specs/AutoPlay.nitro.ts
@@ -68,7 +68,7 @@ export interface AutoPlay extends HybridObject<{ android: 'kotlin'; ios: 'swift'
   /**
    * update a templates headerActions
    */
-  setTemplateHeaderActions(templateId: string, headerActions?: Array<NitroAction>): void;
+  setTemplateHeaderActions(templateId: string, headerActions?: Array<NitroAction>): Promise<void>;
 
   /**
    * Check if AutoPlay is connected.

--- a/packages/react-native-autoplay/src/specs/GridTemplate.nitro.ts
+++ b/packages/react-native-autoplay/src/specs/GridTemplate.nitro.ts
@@ -7,5 +7,5 @@ interface GridTemplateConfig extends NitroTemplateConfig, NitroGridTemplateConfi
 
 export interface GridTemplate extends HybridObject<{ android: 'kotlin'; ios: 'swift' }> {
   createGridTemplate(config: GridTemplateConfig): void;
-  updateGridTemplateButtons(templateId: string, buttons: Array<NitroGridButton>): void;
+  updateGridTemplateButtons(templateId: string, buttons: Array<NitroGridButton>): Promise<void>;
 }

--- a/packages/react-native-autoplay/src/specs/InformationTemplate.nitro.ts
+++ b/packages/react-native-autoplay/src/specs/InformationTemplate.nitro.ts
@@ -9,5 +9,5 @@ export interface InformationTemplate extends HybridObject<{ android: 'kotlin'; i
   updateInformationTemplateSections(
     templateId: string,
     section: NitroInformationTemplateConfig['section']
-  ): void;
+  ): Promise<void>;
 }

--- a/packages/react-native-autoplay/src/specs/ListTemplate.nitro.ts
+++ b/packages/react-native-autoplay/src/specs/ListTemplate.nitro.ts
@@ -9,5 +9,5 @@ export interface ListTemplate extends HybridObject<{ android: 'kotlin'; ios: 'sw
   updateListTemplateSections(
     templateId: string,
     sections: NitroListTemplateConfig['sections']
-  ): void;
+  ): Promise<void>;
 }

--- a/packages/react-native-autoplay/src/specs/MapTemplate.nitro.ts
+++ b/packages/react-native-autoplay/src/specs/MapTemplate.nitro.ts
@@ -39,7 +39,7 @@ export interface MapTemplate extends HybridObject<{ android: 'kotlin'; ios: 'swi
     mapButtons: Array<NitroMapButton>
   ): TripSelectorCallback;
   hideTripSelector(templateId: string): void;
-  setTemplateMapButtons(templateId: string, buttons?: Array<NitroMapButton>): void;
+  setTemplateMapButtons(templateId: string, buttons?: Array<NitroMapButton>): Promise<void>;
   updateVisibleTravelEstimate(
     templateId: string,
     visibleTravelEstimate: VisibleTravelEstimate

--- a/packages/react-native-autoplay/src/specs/SearchTemplate.nitro.ts
+++ b/packages/react-native-autoplay/src/specs/SearchTemplate.nitro.ts
@@ -6,5 +6,8 @@ interface SearchTemplateConfig extends NitroTemplateConfig, NitroSearchTemplateC
 
 export interface SearchTemplate extends HybridObject<{ android: 'kotlin'; ios: 'swift' }> {
   createSearchTemplate(config: SearchTemplateConfig): void;
-  updateSearchResults(templateId: string, results: NitroSearchTemplateConfig['results']): void;
+  updateSearchResults(
+    templateId: string,
+    results: NitroSearchTemplateConfig['results']
+  ): Promise<void>;
 }

--- a/packages/react-native-autoplay/src/templates/GridTemplate.ts
+++ b/packages/react-native-autoplay/src/templates/GridTemplate.ts
@@ -65,7 +65,7 @@ export class GridTemplate extends Template<GridTemplateConfig, HeaderActions<Gri
   }
 
   public updateGrid(buttons: Array<GridButton<GridTemplate>>) {
-    HybridGridTemplate.updateGridTemplateButtons(
+    return HybridGridTemplate.updateGridTemplateButtons(
       this.id,
       NitroGridUtil.convert(this.template, buttons)
     );

--- a/packages/react-native-autoplay/src/templates/InformationTemplate.ts
+++ b/packages/react-native-autoplay/src/templates/InformationTemplate.ts
@@ -116,7 +116,7 @@ export class InformationTemplate extends Template<
 
   public updateItems(items?: InformationItems) {
     const section = this.getSection(items);
-    HybridInformationTemplate.updateInformationTemplateSections(
+    return HybridInformationTemplate.updateInformationTemplateSections(
       this.id,
       NitroSectionUtil.convert(this.template, section)?.at(0) ?? { items: [], type: 'default' }
     );

--- a/packages/react-native-autoplay/src/templates/ListTemplate.ts
+++ b/packages/react-native-autoplay/src/templates/ListTemplate.ts
@@ -122,7 +122,7 @@ export class ListTemplate extends Template<ListTemplateConfig, HeaderActions<Lis
   }
 
   public updateSections(sections?: Section<ListTemplate>) {
-    HybridListTemplate.updateListTemplateSections(
+    return HybridListTemplate.updateListTemplateSections(
       this.id,
       NitroSectionUtil.convert(this.template, sections)
     );

--- a/packages/react-native-autoplay/src/templates/MapTemplate.ts
+++ b/packages/react-native-autoplay/src/templates/MapTemplate.ts
@@ -198,12 +198,12 @@ export class MapTemplate extends Template<MapTemplateConfig, MapTemplateConfig['
 
   public setMapButtons(mapButtons: MapTemplateConfig['mapButtons']) {
     const buttons = NitroMapButton.convert(this.template, mapButtons);
-    HybridMapTemplate.setTemplateMapButtons(this.id, buttons);
+    return HybridMapTemplate.setTemplateMapButtons(this.id, buttons);
   }
 
   public override setHeaderActions(headerActions: MapTemplateConfig['headerActions']) {
     const nitroActions = NitroActionUtil.convert(this.template, headerActions);
-    HybridAutoPlay.setTemplateHeaderActions(this.id, nitroActions);
+    return HybridAutoPlay.setTemplateHeaderActions(this.id, nitroActions);
   }
 
   /**

--- a/packages/react-native-autoplay/src/templates/SearchTemplate.ts
+++ b/packages/react-native-autoplay/src/templates/SearchTemplate.ts
@@ -87,7 +87,7 @@ export class SearchTemplate extends Template<SearchTemplateConfig, HeaderActions
   }
 
   public updateSearchResults(results?: SingleSection<SearchTemplate>) {
-    HybridSearchTemplate.updateSearchResults(
+    return HybridSearchTemplate.updateSearchResults(
       this.id,
       NitroSectionUtil.convert(this.template, results)?.at(0) ?? {
         items: [],

--- a/packages/react-native-autoplay/src/templates/Template.ts
+++ b/packages/react-native-autoplay/src/templates/Template.ts
@@ -104,6 +104,6 @@ export class Template<TemplateConfigType, ActionsType> {
 
   public setHeaderActions<T>(headerActions?: ActionsType) {
     const nitroActions = NitroActionUtil.convert(headerActions as HeaderActions<T>);
-    HybridAutoPlay.setTemplateHeaderActions(this.id, nitroActions);
+    return HybridAutoPlay.setTemplateHeaderActions(this.id, nitroActions);
   }
 }


### PR DESCRIPTION
This PR fixes the race condition when starting the app and bringing up the trip selector immediately on CarPlay.
Most often the trip selector back button was missing and other buttons that should not have been shown did show up...
This PR makes sure template updates happen on the main thread as the @MainActor annotation on CPTemplate's implies.