### PR TITLE
fix trait collection for CP

### DIFF
--- a/packages/react-native-autoplay/ios/hybrid/HybridAutoPlay.swift
+++ b/packages/react-native-autoplay/ios/hybrid/HybridAutoPlay.swift
@@ -129,14 +129,12 @@ class HybridAutoPlay: HybridAutoPlaySpec {
                 scene,
                 interfaceController in
                 let carPlayTemplate = template.getTemplate()
-                
+
                 if carPlayTemplate is CPMapTemplate {
                     try await MainActor.run {
                         try scene.initRootView()
                     }
                 }
-
-                await template.invalidate()
 
                 let _ = try await interfaceController.setRootTemplate(
                     carPlayTemplate,
@@ -162,9 +160,9 @@ class HybridAutoPlay: HybridAutoPlaySpec {
 
             return try await RootModule.withInterfaceController {
                 interfaceController in
-                
+
                 let carPlayTemplate = template.getTemplate()
-                
+
                 if carPlayTemplate is CPAlertTemplate {
                     let animated = try await
                         !interfaceController.dismissTemplate(

--- a/packages/react-native-autoplay/ios/scenes/AutoPlayScene.swift
+++ b/packages/react-native-autoplay/ios/scenes/AutoPlayScene.swift
@@ -39,6 +39,13 @@ class AutoPlayScene: UIResponder {
             current
         }
 
+        // Get trait collection from the CarPlay interface controller
+        if let carTraitCollection = interfaceController?.interfaceController
+            .carTraitCollection
+        {
+            self.traitCollection = carTraitCollection
+        }
+
         if let window = self.window {
             ViewUtils.showLaunchScreen(window: window)
             safeAreaInsets = window.safeAreaInsets
@@ -64,7 +71,7 @@ class AutoPlayScene: UIResponder {
                 "window nil for module: \(moduleName)"
             )
         }
-        
+
         guard
             let rootView = ViewUtils.getRootView(
                 moduleName: moduleName,
@@ -84,6 +91,11 @@ class AutoPlayScene: UIResponder {
     }
 
     open func traitCollectionDidChange(traitCollection: UITraitCollection) {
+        if self.traitCollection.userInterfaceStyle
+            == traitCollection.userInterfaceStyle
+        {
+            return
+        }
         self.traitCollection = traitCollection
         TemplateStore.traitCollectionDidChange()
     }

--- a/packages/react-native-autoplay/package.json
+++ b/packages/react-native-autoplay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iternio/react-native-auto-play",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Android Auto and Apple CarPlay for react-native",
   "main": "lib/index",
   "module": "lib/index",


### PR DESCRIPTION
Changing the trait collection causes delays on startup of CP. This now uses the trait collection reported when CP connects (and the main screen traitCollection as fallback), so we have less invalidates and faster startup times.