### PR TITLE
fix: race condition when starting trip on CP and calling startNavigation from js

### DIFF
--- a/packages/react-native-autoplay/ios/templates/MapTemplate.swift
+++ b/packages/react-native-autoplay/ios/templates/MapTemplate.swift
@@ -533,15 +533,6 @@ class MapTemplate: NSObject, AutoPlayTemplate, AutoPlayHeaderProviding,
         startedTrip trip: CPTrip,
         using routeChoice: CPRouteChoice
     ) {
-        if let onTripStarted = self.onTripStarted {
-            let tripId = trip.id
-            let routeId = routeChoice.id
-
-            onTripStarted(tripId, routeId)
-        }
-
-        hideTripSelector()
-
         let trip = CPTrip(
             origin: trip.origin,
             destination: trip.destination,
@@ -550,6 +541,15 @@ class MapTemplate: NSObject, AutoPlayTemplate, AutoPlayHeaderProviding,
         )
 
         startNavigation(trip: trip)
+        
+        if let onTripStarted = self.onTripStarted {
+            let tripId = trip.id
+            let routeId = routeChoice.id
+
+            onTripStarted(tripId, routeId)
+        }
+        
+        hideTripSelector()
     }
 
     func updateVisibleTravelEstimate(

--- a/packages/react-native-autoplay/package.json
+++ b/packages/react-native-autoplay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iternio/react-native-auto-play",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Android Auto and Apple CarPlay for react-native",
   "main": "lib/index",
   "module": "lib/index",


### PR DESCRIPTION
This PR makes sure we first start the navigation session and then call the js-callback. In case that one tries to call startNavigation from js it should find the ongoing navigation session having the same ids and therefor do nothing instead of crashing.