### PR TITLE
Refactor header actions handling in MapTemplate

### DIFF
--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/MapTemplate.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/MapTemplate.kt
@@ -5,6 +5,7 @@ import android.graphics.Color
 import androidx.car.app.AppManager
 import androidx.car.app.CarContext
 import androidx.car.app.model.Action
+import androidx.car.app.model.ActionStrip
 import androidx.car.app.model.Alert
 import androidx.car.app.model.AlertCallback
 import androidx.car.app.model.CarColor
@@ -73,8 +74,10 @@ class MapTemplate(
             config.mapButtons?.let { buttons ->
                 setMapActionStrip(Parser.parseMapActions(context, buttons))
             }
-            config.headerActions?.let { headerActions ->
-                setActionStrip(Parser.parseMapHeaderActions(context, headerActions))
+            val headerActionStrip = config.headerActions?.let { headerActions ->
+                Parser.parseMapHeaderActions(context, headerActions)
+             }
+            setActionStrip(headerActionStrip ?: ActionStrip.Builder().build())
             }
             val travelEstimates =
                 if (config.visibleTravelEstimate == VisibleTravelEstimate.FIRST) destinationTravelEstimates.firstOrNull() else destinationTravelEstimates.lastOrNull()


### PR DESCRIPTION
After performing some tests on android i came across this issue within the MapTemplate: 

"java.lang.IllegalStateException: Action strip for this template must be set
	at androidx.car.app.navigation.model.NavigationTemplate$Builder.build(NavigationTemplate.java:388)
	at com.margelo.nitro.swe.iternio.reactnativeautoplay.template.MapTemplate.parse(MapTemplate.kt:96)
	at com.margelo.nitro.swe.iternio.reactnativeautoplay.AndroidAutoScreen.applyConfigUpdate(AndroidAutoScreen.kt:98)
	at com.margelo.nitro.swe.iternio.reactnativeautoplay.HybridAutoPlay$setRootTemplate$1.invokeSuspend(HybridAutoPlay.kt:98)
	at com.margelo.nitro.swe.iternio.reactnativeautoplay.HybridAutoPlay$setRootTemplate$1.invoke(Unknown Source:8)
	at com.margelo.nitro.swe.iternio.reactnativeautoplay.HybridAutoPlay$setRootTemplate$1.invoke(Unknown Source:2)
	at com.margelo.nitro.core.Promise$Companion$async$1.invokeSuspend(Promise.kt:146)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:101)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:589)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:832)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:720)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:707)"

My changes fixed this error for me.