### PR TITLE
Fix AA exceptions

### DIFF
--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/VirtualRenderer.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/VirtualRenderer.kt
@@ -250,7 +250,7 @@ class VirtualRenderer(
     private fun getMapTemplateConfig(): MapTemplateConfig? {
         val screenManager = AndroidAutoScreen.getScreen(moduleName)?.screenManager ?: return null
         val marker = screenManager.top.marker ?: return null
-        return AndroidAutoTemplate.getConfig(marker) as MapTemplateConfig?
+        return AndroidAutoTemplate.getTypedConfig<MapTemplateConfig>(marker)
     }
 
     private fun initRenderer() {

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/MapTemplate.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/MapTemplate.kt
@@ -239,11 +239,19 @@ class MapTemplate(
         fun updateTripDestinations() {
             val tripDestinations = getTripDestinations()
             UiThreadUtil.runOnUiThread {
-                navigationManager.updateTrip(Trip.Builder().apply {
+                val trip = Trip.Builder().apply {
                     tripDestinations.forEach {
                         addDestination(it.key, it.value)
                     }
-                }.build())
+                }.build()
+                try {
+                    navigationManager.updateTrip(trip)
+                } catch(e: IllegalStateException) {
+                    // Sometimes we get a "java.lang.IllegalStateException: Navigation is not started" here, although the navigation
+                    // is started already (we check for isNavigating at the top). So i guess this is a race condition, that we start navigation
+                    // and the AA app is not ready yet. Unfortunately we can not ask the AA app for it's state, so we just catch the error.
+                }
+
             }
         }
 

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/MapTemplate.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/MapTemplate.kt
@@ -380,7 +380,7 @@ class MapTemplate(
             AndroidAutoScreen.invalidateSurfaceScreens()
 
             UiThreadUtil.runOnUiThread {
-                navigationManager.updateTrip(Trip.Builder().apply {
+                val trip = Trip.Builder().apply {
                     addStep(
                         currentStep, Parser.parseTravelEstimates(current.travelEstimates)
                     )
@@ -390,7 +390,14 @@ class MapTemplate(
                     getTripDestinations().forEach {
                         addDestination(it.key, it.value)
                     }
-                }.build())
+                }.build()
+                try {
+                    navigationManager.updateTrip(trip)
+                } catch(exception: IllegalStateException) {
+                    // Sometimes we get a "java.lang.IllegalStateException: Navigation is not started" here, although the navigation
+                    // is started already (we check for isNavigating at the top). So i guess this is a race condition, that we start navigation
+                    // and the AA app is not ready yet. Unfortunately we can not ask the AA app for it's state, so we just catch the error.
+                }
             }
         }
     }

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/TripPreviewTemplate.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/TripPreviewTemplate.kt
@@ -63,10 +63,12 @@ class TripPreviewTemplate(
 
         return MapWithContentTemplate.Builder().apply {
             val pane = Pane.Builder().apply {
-                addRow(Row.Builder().apply {
-                    setTitle(Parser.parseText(selectedRoute.additionalInformationVariants))
-                    addText(Parser.parseText(selectedRoute.selectionSummaryVariants))
-                }.build())
+                selectedRoute.additionalInformationVariants[0]?.let {
+                    addRow(Row.Builder().apply {
+                        setTitle(Parser.parseText(selectedRoute.additionalInformationVariants))
+                        addText(Parser.parseText(selectedRoute.selectionSummaryVariants))
+                    }.build())
+                }
                 addRow(Row.Builder().apply {
                     setTitle(
                         "${textConfig.travelEstimatesTitle} ${

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/TripPreviewTemplate.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/TripPreviewTemplate.kt
@@ -63,7 +63,8 @@ class TripPreviewTemplate(
 
         return MapWithContentTemplate.Builder().apply {
             val pane = Pane.Builder().apply {
-                selectedRoute.additionalInformationVariants[0]?.let {
+                selectedRoute.additionalInformationVariants.firstOrNull()
+                    ?.takeIf { it.isNotEmpty() }?.let {
                     addRow(Row.Builder().apply {
                         setTitle(Parser.parseText(selectedRoute.additionalInformationVariants))
                         addText(Parser.parseText(selectedRoute.selectionSummaryVariants))

--- a/packages/react-native-autoplay/package.json
+++ b/packages/react-native-autoplay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iternio/react-native-auto-play",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Android Auto and Apple CarPlay for react-native",
   "main": "lib/index",
   "module": "lib/index",

--- a/packages/react-native-autoplay/package.json
+++ b/packages/react-native-autoplay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iternio/react-native-auto-play",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Android Auto and Apple CarPlay for react-native",
   "main": "lib/index",
   "module": "lib/index",


### PR DESCRIPTION
Fixes following crashes we got:

```
Exception java.lang.ClassCastException:
  at com.margelo.nitro.swe.iternio.reactnativeautoplay.VirtualRenderer.getMapTemplateConfig (VirtualRenderer.kt:253)
  at com.margelo.nitro.swe.iternio.reactnativeautoplay.VirtualRenderer.access$getMapTemplateConfig (VirtualRenderer.kt:40)
  at com.margelo.nitro.swe.iternio.reactnativeautoplay.VirtualRenderer$2.onScroll (VirtualRenderer.kt:122)
  at androidx.car.app.utils.RemoteUtils$SurfaceCallbackStub.lambda$onScroll$4$androidx-car-app-utils-RemoteUtils$SurfaceCallbackStub (RemoteUtils.java:346)
  at androidx.car.app.utils.RemoteUtils$SurfaceCallbackStub$$ExternalSyntheticLambda4.dispatch (D8$$SyntheticClass)
  at androidx.car.app.utils.RemoteUtils.lambda$dispatchCallFromHost$2 (RemoteUtils.java:203)
  at androidx.car.app.utils.RemoteUtils$$ExternalSyntheticLambda0.run (D8$$SyntheticClass)
  at android.os.Handler.handleCallback (Handler.java:1041)
  at android.os.Handler.dispatchMessage (Handler.java:103)
  at android.os.Looper.dispatchMessage (Looper.java:315)
  at android.os.Looper.loopOnce (Looper.java:251)
  at android.os.Looper.loop (Looper.java:349)
  at android.app.ActivityThread.main (ActivityThread.java:9041)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:593)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:929)
```

```
Exception java.lang.RuntimeException:
  at androidx.car.app.utils.RemoteUtils.lambda$dispatchCallFromHost$0 (RemoteUtils.java:153)
  at androidx.car.app.utils.RemoteUtils$$ExternalSyntheticLambda3.run (D8$$SyntheticClass)
  at androidx.car.app.utils.ThreadUtils.runOnMain (ThreadUtils.java:39)
  at androidx.car.app.utils.RemoteUtils.dispatchCallFromHost (RemoteUtils.java:145)
  at androidx.car.app.utils.RemoteUtils.lambda$dispatchCallFromHost$1 (RemoteUtils.java:184)
  at androidx.car.app.utils.RemoteUtils$$ExternalSyntheticLambda4.run (D8$$SyntheticClass)
  at android.os.Handler.handleCallback (Handler.java:1027)
  at android.os.Handler.dispatchMessage (Handler.java:108)
  at android.os.Looper.loopOnce (Looper.java:298)
  at android.os.Looper.loop (Looper.java:408)
  at android.app.ActivityThread.main (ActivityThread.java:9952)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:613)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1074)
Caused by java.lang.IllegalArgumentException: The title cannot be null or empty
  at androidx.car.app.model.Row$Builder.setTitle (Row.java:395)
  at com.margelo.nitro.swe.iternio.reactnativeautoplay.template.TripPreviewTemplate.onGetTemplate (TripPreviewTemplate.kt:67)
  at androidx.car.app.Screen.getTemplateWrapper (Screen.java:350)
  at androidx.car.app.ScreenManager.getTopTemplate (ScreenManager.java:287)
  at androidx.car.app.AppManager$1$$ExternalSyntheticLambda1.dispatch (D8$$SyntheticClass)
  at androidx.car.app.utils.RemoteUtils.lambda$dispatchCallFromHost$0 (RemoteUtils.java:148)
```

```
java.lang.IllegalStateException: Navigation is not started
    at androidx.car.app.navigation.NavigationManager.updateTrip(NavigationManager.java:112)
    at com.margelo.nitro.swe.iternio.reactnativeautoplay.template.MapTemplate$Companion.updateManeuvers$lambda$18(MapTemplate.kt:388)
    at com.margelo.nitro.swe.iternio.reactnativeautoplay.template.MapTemplate$Companion.$r8$lambda$LTpjW_91IvgnSbL0_R7BR7EK7Ng(:0)
    at com.margelo.nitro.swe.iternio.reactnativeautoplay.template.MapTemplate$Companion$$ExternalSyntheticLambda3.run(D8$$SyntheticClass:0)
    at android.os.Handler.handleCallback(Handler.java:1070)
    at android.os.Handler.dispatchMessage(Handler.java:125)
    at android.os.Looper.dispatchMessage(Looper.java:333)
    at android.os.Looper.loopOnce(Looper.java:263)
    at android.os.Looper.loop(Looper.java:367)
    at android.app.ActivityThread.main(ActivityThread.java:9287)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:566)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:929)
```