### PR TITLE
Refactor header actions handling in MapTemplate

### DIFF
--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/MapTemplate.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/MapTemplate.kt
@@ -74,23 +74,15 @@ class MapTemplate(
             config.mapButtons?.let { buttons ->
                 setMapActionStrip(Parser.parseMapActions(context, buttons))
             }
-            val headerActionStrip = config.headerActions?.let { headerActions ->
-                Parser.parseMapHeaderActions(context, headerActions)
+                        config.headerActions?.let { headerActions ->
+                setActionStrip(Parser.parseMapHeaderActions(context, headerActions))
             } ?: run {
-                ActionStrip.Builder()
-                    .addAction(
-                        Action.Builder()
-                            .setIcon(
-                                CarIcon.Builder(IconCompat.createWithResource(context, R.drawable.ic_launcher))
-                                    .build()
-                            )
-                            .setOnClickListener { /* No-op, just satisfies requirement */ }
-                            .build()
-                    )
-                    .build()
+                setActionStrip(
+                    ActionStrip.Builder()
+                        .addAction(Action.APP_ICON)
+                        .build()
+                )
             }
-            setActionStrip(headerActionStrip)
-            
             val travelEstimates =
                 if (config.visibleTravelEstimate == VisibleTravelEstimate.FIRST) destinationTravelEstimates.firstOrNull() else destinationTravelEstimates.lastOrNull()
             travelEstimates?.let {

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/MapTemplate.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/MapTemplate.kt
@@ -77,8 +77,18 @@ class MapTemplate(
             val headerActionStrip = config.headerActions?.let { headerActions ->
                 Parser.parseMapHeaderActions(context, headerActions)
             } ?: run {
-                Log.w("MapTemplate", "No header actions provided, using empty ActionStrip")
-                ActionStrip.Builder().build()
+                Log.w("MapTemplate", "No header actions provided, using app icon as fallback")
+                ActionStrip.Builder()
+                    .addAction(
+                        Action.Builder()
+                            .setIcon(
+                                CarIcon.Builder(IconCompat.createWithResource(context, R.drawable.ic_launcher))
+                                    .build()
+                            )
+                            .setOnClickListener { /* No-op, just satisfies requirement */ }
+                            .build()
+                    )
+                    .build()
             }
             setActionStrip(headerActionStrip)
             

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/MapTemplate.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/MapTemplate.kt
@@ -5,6 +5,7 @@ import android.graphics.Color
 import androidx.car.app.AppManager
 import androidx.car.app.CarContext
 import androidx.car.app.model.Action
+import androidx.car.app.model.ActionStrip
 import androidx.car.app.model.Alert
 import androidx.car.app.model.AlertCallback
 import androidx.car.app.model.CarColor
@@ -73,8 +74,10 @@ class MapTemplate(
             config.mapButtons?.let { buttons ->
                 setMapActionStrip(Parser.parseMapActions(context, buttons))
             }
-            config.headerActions?.let { headerActions ->
-                setActionStrip(Parser.parseMapHeaderActions(context, headerActions))
+            val headerActionStrip = config.headerActions?.let { headerActions ->
+                Parser.parseMapHeaderActions(context, headerActions)
+             }
+            setActionStrip(headerActionStrip ?: ActionStrip.Builder().build())
             }
             val travelEstimates =
                 if (config.visibleTravelEstimate == VisibleTravelEstimate.FIRST) destinationTravelEstimates.firstOrNull() else destinationTravelEstimates.lastOrNull()

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/MapTemplate.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/MapTemplate.kt
@@ -77,7 +77,6 @@ class MapTemplate(
             val headerActionStrip = config.headerActions?.let { headerActions ->
                 Parser.parseMapHeaderActions(context, headerActions)
             } ?: run {
-                Log.w("MapTemplate", "No header actions provided, using app icon as fallback")
                 ActionStrip.Builder()
                     .addAction(
                         Action.Builder()

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/MapTemplate.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/MapTemplate.kt
@@ -81,7 +81,7 @@ class MapTemplate(
                 ActionStrip.Builder().build()
             }
             setActionStrip(headerActionStrip)
-            }
+            
             val travelEstimates =
                 if (config.visibleTravelEstimate == VisibleTravelEstimate.FIRST) destinationTravelEstimates.firstOrNull() else destinationTravelEstimates.lastOrNull()
             travelEstimates?.let {

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/MapTemplate.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/MapTemplate.kt
@@ -74,7 +74,7 @@ class MapTemplate(
             config.mapButtons?.let { buttons ->
                 setMapActionStrip(Parser.parseMapActions(context, buttons))
             }
-                        config.headerActions?.let { headerActions ->
+            config.headerActions?.let { headerActions ->
                 setActionStrip(Parser.parseMapHeaderActions(context, headerActions))
             } ?: run {
                 setActionStrip(

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/MapTemplate.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/MapTemplate.kt
@@ -76,8 +76,11 @@ class MapTemplate(
             }
             val headerActionStrip = config.headerActions?.let { headerActions ->
                 Parser.parseMapHeaderActions(context, headerActions)
-             }
-            setActionStrip(headerActionStrip ?: ActionStrip.Builder().build())
+            } ?: run {
+                Log.w("MapTemplate", "No header actions provided, using empty ActionStrip")
+                ActionStrip.Builder().build()
+            }
+            setActionStrip(headerActionStrip)
             }
             val travelEstimates =
                 if (config.visibleTravelEstimate == VisibleTravelEstimate.FIRST) destinationTravelEstimates.firstOrNull() else destinationTravelEstimates.lastOrNull()


### PR DESCRIPTION
# Fix: Ensure ActionStrip is always set for NavigationTemplate

## Problem
Android Auto's `NavigationTemplate` requires an `ActionStrip` to be set, otherwise it throws an `IllegalStateException` during build:

```
java.lang.IllegalStateException: Action strip for this template must be set
at androidx.car.app.navigation.model.NavigationTemplate$Builder.build
```

This crash occurred when `config.headerActions` was `null` or not provided, as the previous implementation would skip calling `setActionStrip()` entirely.

As ActionStrip needs at least one Action as a fallback the app icon is rendered

```
java.lang.IllegalStateException: Action strip must contain at least one action
```

## Solution
- Always call `setActionStrip()`, even when no header actions are configured
- Provide an empty `ActionStrip` as a fallback when `config.headerActions` is null
- Add logging to help debug cases where the fallback is used

## Changes
**Before:**
```kotlin
config.headerActions?.let { headerActions ->
    setActionStrip(Parser.parseMapHeaderActions(context, headerActions))
}
```

**After:**
```kotlin
val headerActionStrip = config.headerActions?.let { headerActions ->
    Parser.parseMapHeaderActions(context, headerActions)
} ?: run {
    Log.w("MapTemplate", "No header actions provided, using empty ActionStrip")
    ActionStrip.Builder().build()
}
setActionStrip(headerActionStrip)
```

## Testing
- Verified that templates without header actions no longer crash
- Confirmed that templates with header actions continue to work as expected