### PR TITLE
docs: refresh AutoPlay README reference

### DIFF
--- a/packages/react-native-autoplay/README.md
+++ b/packages/react-native-autoplay/README.md
@@ -433,7 +433,7 @@ Below is a concise overview of the most important props per template. Optional p
 
 ### Header Actions (Important)
 
-On Android, header actions are now **safe to omit**: if `headerActions` is `undefined`, the system will render the **app icon** automatically. If you _do_ pass actions, they must include alignment information to avoid native errors.
+On Android, header actions may be omitted, although this is not recommended. If `headerActions` is `undefined`, the system automatically renders the app icon in the header. Because Android Auto enforces monochrome icons, this can result in a poor-looking button.
 
 **Use these rules to avoid crashes:**
 

--- a/packages/react-native-autoplay/README.md
+++ b/packages/react-native-autoplay/README.md
@@ -378,7 +378,7 @@ Below is a concise overview of the most important props per template. Optional p
 | `visibleTravelEstimate` | `'first'` `'last'` | ❌ | Which travel estimate to display. |
 | `onDidPan` / `onDidUpdateZoomGestureWithCenter` | callbacks | ❌ | Map gesture events. |
 | `onAppearanceDidChange` | `(colorScheme) => void` | ❌ | Listen for light/dark mode changes. |
-| `onAutoDriveEnabled` | `(template) => void` | ❌ | Android-only auto drive callback. |
+| `onAutoDriveEnabled` | `(template) => void` | ⚠️ | Android-only auto drive callback. Make sure to take action when receiving this and simulate a drive to the set destination. [Check Android docs for details](https://developer.android.com/reference/androidx/car/app/navigation/NavigationManagerCallback#onAutoDriveEnabled()) |
 
 #### ListTemplateConfig
 

--- a/packages/react-native-autoplay/README.md
+++ b/packages/react-native-autoplay/README.md
@@ -375,7 +375,7 @@ Below is a concise overview of the most important props per template. Optional p
 | `onStopNavigation` | `(template: MapTemplate) => void` | ✅ | Called when navigation is stopped by the system. |
 | `headerActions` | `MapHeaderActions<MapTemplate>` | ❌ | Top action strip. See **Header Actions** below. |
 | `mapButtons` | `MapButtons<MapTemplate>` | ❌ | 1–4 map buttons shown on the map. |
-| `visibleTravelEstimate` | `'first' | 'last'` | ❌ | Which travel estimate to display. |
+| `visibleTravelEstimate` | `'first'` `'last'` | ❌ | Which travel estimate to display. |
 | `onDidPan` / `onDidUpdateZoomGestureWithCenter` | callbacks | ❌ | Map gesture events. |
 | `onAppearanceDidChange` | `(colorScheme) => void` | ❌ | Listen for light/dark mode changes. |
 | `onAutoDriveEnabled` | `(template) => void` | ❌ | Android-only auto drive callback. |
@@ -502,7 +502,7 @@ This section lists the available listeners and lifecycle callbacks so you can wi
 
 | API | Payload | Notes |
 | --- | --- | --- |
-| `HybridAutoPlay.addListener(event, cb)` | `event: 'didConnect' | 'didDisconnect'` | Connection changes for the head unit. |
+| `HybridAutoPlay.addListener(event, cb)` | event: `'didConnect'` `'didDisconnect'` | Connection changes for the head unit. |
 | `HybridAutoPlay.addListenerRenderState(moduleName, cb)` | `cb(visibility: 'willAppear' \| 'didAppear' \| 'willDisappear' \| 'didDisappear')` | Use `AutoPlayModules.*` or a cluster UUID. |
 | `HybridAutoPlay.addListenerVoiceInput(cb)` | `cb(location?, query?)` | Android-only voice input. |
 | `HybridAutoPlay.addSafeAreaInsetsListener(moduleName, cb)` | `cb(insets)` | Safe area inset changes for any module. |
@@ -569,7 +569,7 @@ const removeCompass = AutoPlayCluster.addListenerCompass((clusterId, enabled) =>
 
 | API | Payload | Notes |
 | --- | --- | --- |
-| `CarPlayDashboard.addListener(event, cb)` | `event: 'didConnect' | 'didDisconnect'` | Connection changes for the dashboard scene. |
+| `CarPlayDashboard.addListener(event, cb)` | event: `'didConnect'` `'didDisconnect'` | Connection changes for the dashboard scene. |
 | `CarPlayDashboard.addListenerRenderState(cb)` | `cb(visibility)` | Scene visibility changes. |
 | `CarPlayDashboard.addListenerColorScheme(cb)` | `cb(colorScheme)` | Light/dark changes. |
 

--- a/packages/react-native-autoplay/README.md
+++ b/packages/react-native-autoplay/README.md
@@ -394,7 +394,7 @@ Below is a concise overview of the most important props per template. Optional p
 | Prop | Type | Required | Notes |
 | --- | --- | --- | --- |
 | `title` | `AutoText` | ✅ | Header title. |
-| `buttons` | `GridButton<GridTemplate>[]` | ✅ | Grid items. |
+| `buttons` | `GridButton<GridTemplate>[]` | ✅ | Grid items. Providing an empty array will result in a loading indicator on Android and an empty template on iOS. |
 | `headerActions` | `HeaderActions<GridTemplate>` | ❌ | Header actions. See **Header Actions** below. |
 | `mapConfig` | `BaseMapTemplateConfig<GridTemplate>` | ❌ | Android map-with-content layout. |
 

--- a/packages/react-native-autoplay/README.md
+++ b/packages/react-native-autoplay/README.md
@@ -385,7 +385,7 @@ Below is a concise overview of the most important props per template. Optional p
 | Prop | Type | Required | Notes |
 | --- | --- | --- | --- |
 | `title` | `AutoText` | ✅ | Header title. |
-| `sections` | `Section<ListTemplate>` | ❌ | List sections/rows. |
+| `sections` | `Section<ListTemplate>` | ❌ | List sections/rows. Not providing anything here will result in a loading indicator on Android and an empty list on iOS. |
 | `headerActions` | `HeaderActions<ListTemplate>` | ❌ | Header actions. See **Header Actions** below. |
 | `mapConfig` | `BaseMapTemplateConfig<ListTemplate>` | ❌ | Android map-with-content layout. |
 


### PR DESCRIPTION
- expand the README with a structured API reference for templates, listeners, scenes, and core types
- add concise usage examples and tables for easier navigation
- tighten layout/organization for readability