### PR TITLE
Check if UI manager is initialized and set proper theme

### DIFF
--- a/packages/react-native-autoplay/package.json
+++ b/packages/react-native-autoplay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iternio/react-native-auto-play",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Android Auto and Apple CarPlay for react-native",
   "main": "lib/index",
   "module": "lib/index",


### PR DESCRIPTION
We already had a check for new arch, now we do the same for old arch. This should fix errors like

```
java.lang.IllegalStateException: Unable to attach a rootView to ReactInstance when UIManager is not properly initialized.
```

And
```
View class com.facebook.react.views.text.ReactTextView is an AppCompat widget that can only be used with a Theme.AppCompat theme (or descendant).
```