### PR TITLE
Fix CW roundabout angle

### DIFF
--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/Parser.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/Parser.kt
@@ -654,9 +654,13 @@ object Parser {
                     setRoundaboutExitNumber(it.toInt())
                 }
                 nitroManeuver.angle?.let { roundaboutExitAngle ->
-                    val angle =
-                        ((180 - roundaboutExitAngle) % 360).toInt().let { if (it == 0) 360 else it }
-                    setRoundaboutExitAngle(angle)
+                    if (nitroManeuver.trafficSide == TrafficSide.LEFT) {
+                        val angle = ((180 + roundaboutExitAngle) % 360).toInt().let { if (it == 0) 360 else it }
+                        setRoundaboutExitAngle(angle)
+                    } else {
+                        val angle = ((180 - roundaboutExitAngle) % 360).toInt().let { if (it == 0) 360 else it }
+                        setRoundaboutExitAngle(angle)
+                    }
                 }
             }
         }.build()

--- a/packages/react-native-autoplay/package.json
+++ b/packages/react-native-autoplay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iternio/react-native-auto-play",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Android Auto and Apple CarPlay for react-native",
   "main": "lib/index",
   "module": "lib/index",


### PR DESCRIPTION
The input param is angle in degrees. 0 means straight, -90 left, +90 right. For CW right needs the full 270° angle, so we need to pass it as +90 and then the logic calculates it properly. So far this only worked for CCW, in CW the instructions were mirrored, so we need to add the additional calculation.