### PR TITLE
fix: Fix nil crash in SceneStore.getRootTraitCollection when root scene isn’t ready

### DIFF
--- a/packages/react-native-autoplay/ios/scenes/SceneStore.swift
+++ b/packages/react-native-autoplay/ios/scenes/SceneStore.swift
@@ -85,6 +85,9 @@ class SceneStore {
     }
 
     static func getRootTraitCollection() -> UITraitCollection {
-        return store[SceneStore.rootModuleName]!.traitCollection
+        guard let scene = store[SceneStore.rootModuleName] else {
+            return UITraitCollection()
+        }
+        return scene.traitCollection
     }
 }


### PR DESCRIPTION
Bug: SceneStore.getRootTraitCollection() force‑unwraps a nil scene.
Symptom: App crashes on CarPlay connect with Fatal error: Unexpectedly found nil while unwrapping an Optional value.
("ReactNativeAutoPlay/SceneStore.swift:88: Fatal error: Unexpectedly found nil while unwrapping an Optional value")
Fix: Return default UITraitCollection() if root scene is missing.