### PR TITLE
move invalidate inside withSceneAndInterfaceController

### DIFF
--- a/packages/react-native-autoplay/ios/hybrid/HybridAutoPlay.swift
+++ b/packages/react-native-autoplay/ios/hybrid/HybridAutoPlay.swift
@@ -140,12 +140,8 @@ class HybridAutoPlay: HybridAutoPlaySpec {
                     carPlayTemplate,
                     animated: false
                 )
-            }
 
-            DispatchQueue.main.async {
-                if let template = TemplateStore.getTemplate(
-                    templateId: templateId
-                ) {
+                try await MainActor.run {
                     template.invalidate()
                 }
             }

--- a/packages/react-native-autoplay/ios/hybrid/HybridAutoPlay.swift
+++ b/packages/react-native-autoplay/ios/hybrid/HybridAutoPlay.swift
@@ -141,9 +141,7 @@ class HybridAutoPlay: HybridAutoPlaySpec {
                     animated: false
                 )
 
-                try await MainActor.run {
-                    template.invalidate()
-                }
+                await template.invalidate()
             }
         }
     }


### PR DESCRIPTION
Potential fix for a crash we saw:
```
CXX: calling C++ destructors for class %s

Thread 0 Crashed:
0   ABRP                            0x202c63638         MapTemplate.invalidate
1   ABRP                            0x202c6a08c         MapTemplate
2   ABRP                            0x202c39464         closure in HybridAutoPlay.setRootTemplate
3   ABRP                            0x20258d024         thunk for closure
4   libdispatch.dylib               0x3972a9ad8         _dispatch_call_block_and_release
5   libdispatch.dylib               0x3972c37f8         _dispatch_client_callout
6   libdispatch.dylib               0x3972e0b0c         _dispatch_main_queue_drain.cold.5
7   libdispatch.dylib               0x3972b8ec4         _dispatch_main_queue_drain
8   libdispatch.dylib               0x3972b8e00         _dispatch_main_queue_callback_4CF
9   CoreFoundation                  0x325cc82b0         __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__
10  CoreFoundation                  0x325c7bb38         __CFRunLoopRun
11  CoreFoundation                  0x325c7aa68         _CFRunLoopRunSpecificWithOptions
12  GraphicsServices                0x4694f3494         GSEventRunModal
13  UIKitCore                       0x330fabdf4         -[UIApplication _run]
14  UIKitCore                       0x330f54e50         UIApplicationMain
15  ABRP                            0x2023f9da0         main
16  dyld                            0x31fc6ce24         start
```

The issue seems to be that invalidate() was called asynchronously with DispatchQueue.main.async so it was put onto the main queue, but not executed yet. So when during setting root template and invalidating it something would happen to the CP connection, the CPMapTemplate would be deallocated resulting in the above error.

So the idea is to move invalidate right after setRootTemplate and await it, so it finishes, before the promise resolves.