### PR TITLE
Fix trait collection crash

### DIFF
--- a/packages/react-native-autoplay/ios/scenes/AutoPlayScene.swift
+++ b/packages/react-native-autoplay/ios/scenes/AutoPlayScene.swift
@@ -90,6 +90,7 @@ class AutoPlayScene: UIResponder {
         window.makeKeyAndVisible()
     }
 
+    @MainActor
     open func traitCollectionDidChange(traitCollection: UITraitCollection) {
         if self.traitCollection.userInterfaceStyle
             == traitCollection.userInterfaceStyle

--- a/packages/react-native-autoplay/ios/scenes/AutoPlaySceneViewController.swift
+++ b/packages/react-native-autoplay/ios/scenes/AutoPlaySceneViewController.swift
@@ -19,17 +19,18 @@ class AutoPlaySceneViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    @MainActor
     override func traitCollectionDidChange(
         _ previousTraitCollection: UITraitCollection?
     ) {
-        SceneStore.getScene(moduleName: moduleName)!.traitCollectionDidChange(
+        SceneStore.getScene(moduleName: moduleName)?.traitCollectionDidChange(
             traitCollection: traitCollection
         )
     }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        SceneStore.getScene(moduleName: moduleName)!.safeAreaInsetsDidChange(
+        SceneStore.getScene(moduleName: moduleName)?.safeAreaInsetsDidChange(
             safeAreaInsets: self.view.safeAreaInsets
         )
     }

--- a/packages/react-native-autoplay/ios/scenes/ClusterSceneDelegate.swift
+++ b/packages/react-native-autoplay/ios/scenes/ClusterSceneDelegate.swift
@@ -128,6 +128,7 @@ class ClusterSceneDelegate: AutoPlayScene,
     }
 
     // MARK: AutoPlayScene
+    @MainActor
     override func traitCollectionDidChange(traitCollection: UITraitCollection) {
         super.traitCollectionDidChange(traitCollection: traitCollection)
         applyAttributedInactiveDescriptionVariants()

--- a/packages/react-native-autoplay/ios/scenes/DashboardSceneDelegate.swift
+++ b/packages/react-native-autoplay/ios/scenes/DashboardSceneDelegate.swift
@@ -113,6 +113,7 @@ class DashboardSceneDelegate: AutoPlayScene,
         }
     }
 
+    @MainActor
     override func traitCollectionDidChange(traitCollection: UITraitCollection) {
         super.traitCollectionDidChange(traitCollection: traitCollection)
         HybridCarPlayDashboard.emitColorScheme(

--- a/packages/react-native-autoplay/ios/scenes/SceneStore.swift
+++ b/packages/react-native-autoplay/ios/scenes/SceneStore.swift
@@ -85,6 +85,10 @@ class SceneStore {
     }
 
     static func getRootTraitCollection() -> UITraitCollection {
-        return store[SceneStore.rootModuleName]!.traitCollection
+        if let rootScene = store[SceneStore.rootModuleName] {
+            return rootScene.traitCollection
+        }
+        // Fallback to main screen trait collection if root scene is not available
+        return UIScreen.main.traitCollection
     }
 }

--- a/packages/react-native-autoplay/ios/templates/AutoPlayTemplate.swift
+++ b/packages/react-native-autoplay/ios/templates/AutoPlayTemplate.swift
@@ -16,11 +16,12 @@ protocol AutoPlayTemplate {
     func onWillDisappear(animated: Bool)
     func onDidDisappear(animated: Bool)
     func onPopped()
-    func traitCollectionDidChange()
+    @MainActor func traitCollectionDidChange()
     func getTemplate() -> CPTemplate
 }
 
 extension AutoPlayTemplate {
+    @MainActor
     func traitCollectionDidChange() {
         // this can be implemented optionally
     }

--- a/packages/react-native-autoplay/ios/templates/MapTemplate.swift
+++ b/packages/react-native-autoplay/ios/templates/MapTemplate.swift
@@ -178,6 +178,7 @@ class MapTemplate: NSObject, AutoPlayTemplate, AutoPlayHeaderProviding,
         config.onPopped?()
     }
 
+    @MainActor
     func traitCollectionDidChange() {
         let traitCollection = SceneStore.getRootTraitCollection()
         let isDark = traitCollection.userInterfaceStyle == .dark

--- a/packages/react-native-autoplay/ios/templates/TemplateStore.swift
+++ b/packages/react-native-autoplay/ios/templates/TemplateStore.swift
@@ -39,6 +39,7 @@ class TemplateStore {
         store = store.filter { !($0.value.getTemplate() is CPSearchTemplate) }
     }
 
+    @MainActor
     static func traitCollectionDidChange() {
         store.values.forEach { template in template.traitCollectionDidChange() }
     }


### PR DESCRIPTION
Possible fix for 
```
Application Specific Information:
Exception 6, Code 1, Subcode 4346561132

Thread 0 Crashed:
0   ABRP                            0x20313426c         MapTemplate.traitCollectionDidChange
1   ABRP                            0x20313a14c         MapTemplate
2   ABRP                            0x20317e044         TemplateStore.traitCollectionDidChange
3   ABRP                            0x2030ff2c0         DashboardSceneDelegate.traitCollectionDidChange
4   ABRP                            0x2030fbffc         AutoPlaySceneViewController.traitCollectionDidChange
5   UIKitCore                       0x316b07420         -[UIViewController _traitCollectionDidChange:]
6   UIKitCore                       0x316b07640         -[UIViewController _updateTraitsIfNecessarySchedulingPropagation:]
7   UIKitCore                       0x3177fc380         -[UIView _wrappedProcessTraitChanges:withBehavior:]
8   UIKitCore                       0x3177fc528         -[UIView _wrappedProcessTraitChanges:withBehavior:]
9   UIKitCore                       0x317742e10         -[UIView(AdditionalLayoutSupport) _withUnsatisfiableConstraintsLoggingSuspendedIfEngineDelegateExists:]
```

The main culprit probably is the force unwrap.

Cursor also proposed to annotate `traitCollectionDidChange` with `@MainActor`as `invalidate()` also is main actor, which is called in `MapTemplate.traitCollectionDidChange()` and could cause an implicit actor hop, which is inefficient and could cause issues.

Tested with the sample app, also with cluster display, and switching and starting with dark/light mode worked properly.

I also added the optional chaining to `viewDidLayoutSubviews` and that will probably also fix
```
Thread 0 Crashed:
0   ABRP                            0x204a3411c         AutoPlaySceneViewController.viewDidLayoutSubviews
1   ABRP                            0x204a34144         AutoPlaySceneViewController.viewDidLayoutSubviews
2   UIKitCore                       0x3186aaa70         -[UIView(CALayerDelegate) layoutSublayersOfLayer:]
3   QuartzCore                      0x316ef9268         CA::Layer::layout_if_needed
4   QuartzCore                      0x316ef8dec         CA::Layer::layout_and_display_if_needed
```
When a scene is disconnected, SceneStore.removeScene() removes it from the store. If viewDidLayoutSubviews() or traitCollectionDidChange() runs after the scene is removed, the force unwrap crashes.

This might be fixed on 0.2 with the refactoring already, will check after this is merged.