### PR TITLE
Root traitCollection crash fix

### DIFF
--- a/packages/react-native-autoplay/ios/scenes/HeadUnitSceneDelegate.swift
+++ b/packages/react-native-autoplay/ios/scenes/HeadUnitSceneDelegate.swift
@@ -58,13 +58,13 @@ class HeadUnitSceneDelegate: AutoPlayScene, CPTemplateApplicationSceneDelegate {
             CPInterfaceController
     ) {
         HybridAutoPlay.emit(event: .diddisconnect)
-        
+
         if let mapTemplate = try? templateStore.getTemplate(
             templateId: SceneStore.rootModuleName
         ) as? MapTemplate {
             mapTemplate.stopNavigation()
         }
-        
+
         disconnect()
     }
 

--- a/packages/react-native-autoplay/ios/scenes/SceneStore.swift
+++ b/packages/react-native-autoplay/ios/scenes/SceneStore.swift
@@ -85,6 +85,11 @@ class SceneStore {
     }
 
     static func getRootTraitCollection() -> UITraitCollection {
-        return store[SceneStore.rootModuleName]!.traitCollection
+        guard let rootScene = store[SceneStore.rootModuleName]
+        else {
+            // Fallback to main screen trait collection if root scene is not available
+            return UIScreen.main.traitCollection
+        }
+        return rootScene.traitCollection
     }
 }

--- a/packages/react-native-autoplay/ios/templates/GridTemplate.swift
+++ b/packages/react-native-autoplay/ios/templates/GridTemplate.swift
@@ -24,17 +24,17 @@ class GridTemplate: AutoPlayHeaderProviding {
     init(config: GridTemplateConfig) {
         self.config = config
         buttons = config.buttons
-        
+
         template = CPGridTemplate(
             title: Parser.parseText(text: config.title),
             gridButtons: GridTemplate.parseButtons(buttons: buttons),
             id: config.id
         )
-                
+
         super.init()
-        
+
         barButtons = config.headerActions
-        
+
     }
 
     static func parseButtons(buttons: [NitroGridButton]) -> [CPGridButton] {

--- a/packages/react-native-autoplay/ios/templates/InformationTemplate.swift
+++ b/packages/react-native-autoplay/ios/templates/InformationTemplate.swift
@@ -23,7 +23,7 @@ class InformationTemplate: AutoPlayHeaderProviding {
 
     init(config: InformationTemplateConfig) {
         self.config = config
-        
+
         section = config.section
 
         template = CPInformationTemplate(
@@ -33,9 +33,9 @@ class InformationTemplate: AutoPlayHeaderProviding {
             actions: Parser.parseInformationActions(actions: config.actions),
             id: config.id
         )
-        
-        super.init();
-        
+
+        super.init()
+
         barButtons = config.headerActions
     }
 

--- a/packages/react-native-autoplay/ios/templates/ListTemplate.swift
+++ b/packages/react-native-autoplay/ios/templates/ListTemplate.swift
@@ -23,7 +23,7 @@ class ListTemplate: AutoPlayHeaderProviding {
 
     init(config: ListTemplateConfig) {
         self.config = config
-        
+
         sections = config.sections
 
         template = CPListTemplate(
@@ -32,9 +32,9 @@ class ListTemplate: AutoPlayHeaderProviding {
             assistantCellConfiguration: nil,
             id: config.id
         )
-        
+
         super.init()
-        
+
         barButtons = config.headerActions
     }
 

--- a/packages/react-native-autoplay/ios/templates/MapTemplate.swift
+++ b/packages/react-native-autoplay/ios/templates/MapTemplate.swift
@@ -45,10 +45,10 @@ class MapTemplate: AutoPlayHeaderProviding,
 
     init(config: MapTemplateConfig) {
         self.config = config
-        
+
         mapButtons = config.mapButtons
         visibleTravelEstimate = config.visibleTravelEstimate
-        
+
         template = CPMapTemplate(id: config.id)
 
         if let initialProperties = SceneStore.getRootScene()?.initialProperties,

--- a/packages/react-native-autoplay/ios/templates/SearchTemplate.swift
+++ b/packages/react-native-autoplay/ios/templates/SearchTemplate.swift
@@ -28,7 +28,7 @@ class SearchTemplate: AutoPlayTemplate, CPSearchTemplateDelegate {
     init(config: SearchTemplateConfig) {
         self.config = config
         results = config.results
-        
+
         template = CPSearchTemplate(id: config.id)
     }
 


### PR DESCRIPTION
Followup of https://github.com/Iternio-Planning-AB/react-native-auto-play/pull/41, as we will not build another 0.1.x version

Fallback to main traitCollection, if scene is not available for some reason. Probably related to some timing issues, when CP disconnects.