### PR TITLE
Chore/bump nitro 0.33.7

### DIFF
--- a/apps/example/ios/Podfile.lock
+++ b/apps/example/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.81.4):
     - hermes-engine/Pre-built (= 0.81.4)
   - hermes-engine/Pre-built (0.81.4)
-  - NitroModules (0.33.2):
+  - NitroModules (0.33.7):
     - boost
     - DoubleConversion
     - fast_float
@@ -2399,7 +2399,7 @@ PODS:
     - React-perflogger (= 0.81.4)
     - React-utils (= 0.81.4)
     - SocketRocket
-  - ReactNativeAutoPlay (0.1.17):
+  - ReactNativeAutoPlay (0.2.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2676,7 +2676,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 35c763d57c9832d0eef764316ca1c4d043581394
-  NitroModules: dae3143fe7bd2dcc7da1d97c51707c17a3caa163
+  NitroModules: 20e6bc4fd873621019f451d8bfbbf3c973976416
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: c0ed3249a97243002615517dff789bf4666cf585
   RCTRequired: 58719f5124f9267b5f9649c08bf23d9aea845b23
@@ -2742,7 +2742,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: b20fba6c3d091a393925890009999472c8f94d95
   ReactCodegen: cf03d376a26d393f818d511240b026fc8c95313c
   ReactCommon: 00df7b9f859c9d02181844255bb89a8bca544374
-  ReactNativeAutoPlay: 5b82f46e6c66ce5ce079b47be94e5d6f970c2b01
+  ReactNativeAutoPlay: 2253d617acba80d71b550a4a72a629dd4d2ab5f2
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 922d794dce2af9c437f864bf4093abfa7a131adb
 

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -17,7 +17,7 @@
     "react": "19.1.0",
     "react-native": "0.81.4",
     "react-native-config": "^1.6.1",
-    "react-native-nitro-modules": "^0.33.2",
+    "react-native-nitro-modules": "^0.33.7",
     "react-native-safe-area-context": "^5.5.2",
     "react-redux": "^9.2.0"
   },

--- a/apps/example/src/AutoPlay.tsx
+++ b/apps/example/src/AutoPlay.tsx
@@ -37,7 +37,7 @@ const AutoPlayRoot = (props: RootComponentInitialProps) => {
 
   const [i, setI] = useState(0);
 
-  const [signedIn, setSignedIn] = useState(false);
+  const [signedIn, setSignedIn] = useState(Platform.OS !== 'android');
 
   useEffect(() => {
     if (Platform.OS === 'android' && mapTemplate && !signedIn) {

--- a/apps/example/src/AutomotiveView.tsx
+++ b/apps/example/src/AutomotiveView.tsx
@@ -9,7 +9,7 @@ import { Platform, Text, View } from 'react-native';
 import Config from 'react-native-config';
 
 export default function AutomotiveView() {
-  if (Platform.OS !== 'android' || !Config.isAutomotiveApp) {
+  if (Platform.OS !== 'android' || Config.isAutomotiveApp === 'false') {
     return null;
   }
 

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/AssetImage.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/AssetImage.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/AutoText.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/AutoText.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/Distance.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/Distance.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/DurationWithTimeZone.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/DurationWithTimeZone.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_AlertDismissalReason.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_AlertDismissalReason.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_ColorScheme.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_ColorScheme.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_Point.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_Point.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_Point_double.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_Point_double.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_Point_std__optional_Point_.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_Point_std__optional_Point_.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_SafeAreaInsets.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_SafeAreaInsets.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_VisibilityState.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_VisibilityState.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_bool.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_bool.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_std__exception_ptr.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_std__exception_ptr.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_std__optional_Location__std__optional_std__string_.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_std__optional_Location__std__optional_std__string_.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_std__optional_bool_.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_std__optional_bool_.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_std__string.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_std__string.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_std__string_ColorScheme.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_std__string_ColorScheme.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_std__string_ZoomEvent.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_std__string_ZoomEvent.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_std__string_bool.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_std__string_bool.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_std__string_std__string.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/Func_void_std__string_std__string.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/GlyphImage.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/GlyphImage.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/GridTemplateConfig.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/GridTemplateConfig.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridAutoPlaySpec.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridAutoPlaySpec.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /// See ``HybridAutoPlaySpec``

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridAutoPlaySpec_cxx.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridAutoPlaySpec_cxx.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridCarPlayDashboardSpec.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridCarPlayDashboardSpec.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /// See ``HybridCarPlayDashboardSpec``

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridCarPlayDashboardSpec_cxx.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridCarPlayDashboardSpec_cxx.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridClusterSpec.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridClusterSpec.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /// See ``HybridClusterSpec``

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridClusterSpec_cxx.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridClusterSpec_cxx.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridGridTemplateSpec.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridGridTemplateSpec.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /// See ``HybridGridTemplateSpec``

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridGridTemplateSpec_cxx.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridGridTemplateSpec_cxx.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridInformationTemplateSpec.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridInformationTemplateSpec.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /// See ``HybridInformationTemplateSpec``

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridInformationTemplateSpec_cxx.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridInformationTemplateSpec_cxx.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridListTemplateSpec.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridListTemplateSpec.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /// See ``HybridListTemplateSpec``

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridListTemplateSpec_cxx.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridListTemplateSpec_cxx.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridMapTemplateSpec.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridMapTemplateSpec.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /// See ``HybridMapTemplateSpec``

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridMapTemplateSpec_cxx.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridMapTemplateSpec_cxx.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridMessageTemplateSpec.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridMessageTemplateSpec.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /// See ``HybridMessageTemplateSpec``

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridMessageTemplateSpec_cxx.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridMessageTemplateSpec_cxx.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridSearchTemplateSpec.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridSearchTemplateSpec.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /// See ``HybridSearchTemplateSpec``

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridSearchTemplateSpec_cxx.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridSearchTemplateSpec_cxx.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/ImageLane.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/ImageLane.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/InformationTemplateConfig.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/InformationTemplateConfig.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/LaneGuidance.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/LaneGuidance.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/ListTemplateConfig.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/ListTemplateConfig.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/Location.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/Location.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/MapTemplateConfig.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/MapTemplateConfig.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/MessageTemplateConfig.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/MessageTemplateConfig.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/NavigationAlertAction.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/NavigationAlertAction.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroAction.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroAction.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroAttributedString.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroAttributedString.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroAttributedStringImage.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroAttributedStringImage.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroBaseMapTemplateConfig.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroBaseMapTemplateConfig.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroCarPlayDashboardButton.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroCarPlayDashboardButton.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroColor.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroColor.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroGridButton.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroGridButton.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroLoadingManeuver.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroLoadingManeuver.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroMapButton.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroMapButton.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroMessageManeuver.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroMessageManeuver.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroNavigationAlert.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroNavigationAlert.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroRoutingManeuver.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroRoutingManeuver.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroRow.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroRow.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroSection.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroSection.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/Point.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/Point.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/PreferredImageLane.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/PreferredImageLane.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/RouteChoice.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/RouteChoice.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/SafeAreaInsets.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/SafeAreaInsets.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/SearchTemplateConfig.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/SearchTemplateConfig.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/TravelEstimates.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/TravelEstimates.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/TripConfig.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/TripConfig.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/TripPoint.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/TripPoint.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/TripPreviewTextConfiguration.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/TripPreviewTextConfiguration.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/TripSelectorCallback.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/TripSelectorCallback.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/TripsConfig.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/TripsConfig.swift
@@ -5,7 +5,6 @@
 /// Copyright © Marc Rousavy @ Margelo
 ///
 
-import Foundation
 import NitroModules
 
 /**

--- a/packages/react-native-autoplay/package.json
+++ b/packages/react-native-autoplay/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "@types/react": "^19.1.03",
-    "nitrogen": "^0.33.2",
+    "nitrogen": "^0.33.7",
     "typescript": "^5.8.3"
   },
   "peerDependencies": {

--- a/patches/expo-splash-screen+31.0.13.patch
+++ b/patches/expo-splash-screen+31.0.13.patch
@@ -1,0 +1,345 @@
+diff --git a/node_modules/expo-splash-screen/build/index.d.ts b/node_modules/expo-splash-screen/build/index.d.ts
+index 2bbd5cd..08f7a97 100644
+--- a/node_modules/expo-splash-screen/build/index.d.ts
++++ b/node_modules/expo-splash-screen/build/index.d.ts
+@@ -29,11 +29,11 @@ export declare function setOptions(options: SplashScreenOptions): void;
+  * to display when you hide the splash screen, or you may see a blank screen briefly. See the
+  * ["Usage"](#usage) section for an example.
+  */
+-export declare function hide(): void;
++export declare function hide(moduleName?: string): void;
+ /**
+  * Hides the native splash screen immediately. This method is provided for backwards compatability. See the
+  * ["Usage"](#usage) section for an example.
+  */
+-export declare function hideAsync(): Promise<void>;
++export declare function hideAsync(moduleName?: string): Promise<void>;
+ export { SplashScreenOptions };
+ //# sourceMappingURL=index.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/expo-splash-screen/build/index.js b/node_modules/expo-splash-screen/build/index.js
+index 91b253a..f57aaa8 100644
+--- a/node_modules/expo-splash-screen/build/index.js
++++ b/node_modules/expo-splash-screen/build/index.js
+@@ -32,10 +32,10 @@ export function setOptions(options) { }
+  * to display when you hide the splash screen, or you may see a blank screen briefly. See the
+  * ["Usage"](#usage) section for an example.
+  */
+-export function hide() { }
++export function hide(moduleName) { }
+ /**
+  * Hides the native splash screen immediately. This method is provided for backwards compatability. See the
+  * ["Usage"](#usage) section for an example.
+  */
+-export async function hideAsync() { }
++export async function hideAsync(moduleName) { }
+ //# sourceMappingURL=index.js.map
+\ No newline at end of file
+diff --git a/node_modules/expo-splash-screen/build/index.native.d.ts b/node_modules/expo-splash-screen/build/index.native.d.ts
+index e823128..7a72e6f 100644
+--- a/node_modules/expo-splash-screen/build/index.native.d.ts
++++ b/node_modules/expo-splash-screen/build/index.native.d.ts
+@@ -1,6 +1,6 @@
+ import { SplashScreenOptions } from './SplashScreen.types';
+ export declare function setOptions(options: SplashScreenOptions): void;
+ export declare function hide(): void;
+-export declare function hideAsync(): Promise<void>;
+-export declare function preventAutoHideAsync(): Promise<boolean | undefined>;
++export declare function hideAsync(moduleName?: string): Promise<void>;
++export declare function preventAutoHideAsync(moduleName?: string): Promise<boolean | undefined>;
+ //# sourceMappingURL=index.native.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/expo-splash-screen/build/index.native.js b/node_modules/expo-splash-screen/build/index.native.js
+index d0b0815..c844b86 100644
+--- a/node_modules/expo-splash-screen/build/index.native.js
++++ b/node_modules/expo-splash-screen/build/index.native.js
+@@ -1,5 +1,6 @@
+ import { isRunningInExpoGo } from 'expo';
+ import { requireOptionalNativeModule } from 'expo-modules-core';
++import { Platform } from 'react-native';
+ const SplashModule = requireOptionalNativeModule('ExpoSplashScreen');
+ export function setOptions(options) {
+     if (!SplashModule) {
+@@ -11,14 +12,18 @@ export function setOptions(options) {
+     }
+     SplashModule.setOptions(options);
+ }
+-export function hide() {
++export function hide(moduleName) {
+     if (!SplashModule) {
+         return;
+     }
++    if (Platform.OS === 'ios') {
++        SplashModule.hide(moduleName);
++        return;
++    }
+     SplashModule.hide();
+ }
+-export async function hideAsync() {
+-    hide();
++export async function hideAsync(moduleName) {
++    hide(moduleName);
+ }
+ export async function preventAutoHideAsync() {
+     if (!SplashModule) {
+diff --git a/node_modules/expo-splash-screen/ios/.DS_Store b/node_modules/expo-splash-screen/ios/.DS_Store
+new file mode 100644
+index 0000000..5008ddf
+Binary files /dev/null and b/node_modules/expo-splash-screen/ios/.DS_Store differ
+diff --git a/node_modules/expo-splash-screen/ios/SplashScreenManager.swift b/node_modules/expo-splash-screen/ios/SplashScreenManager.swift
+index fe4ad94..8b81c8b 100644
+--- a/node_modules/expo-splash-screen/ios/SplashScreenManager.swift
++++ b/node_modules/expo-splash-screen/ios/SplashScreenManager.swift
+@@ -3,51 +3,83 @@ import UIKit
+ import ExpoModulesCore
+ 
+ public class SplashScreenManager: NSObject, RCTReloadListener {
++  let splashScreenIdentifier = "Expo.SplashScreen.LoadingView"
++
+   @objc public static let shared = SplashScreenManager()
+-  private var loadingView: UIView?
+-  private var rootView: UIView?
++  @MainActor private var rootView: [String: UIView] = [:]
+   private var options = SplashScreenOptions()
+   public var preventAutoHideCalled = false
+ 
+-  private override init() {}
++  private override init() {
++      super.init()
++      
++      NotificationCenter.default.addObserver(self, selector: #selector(onAppReady), name: Notification.Name("RCTContentDidAppearNotification"), object: nil)
++  }
+ 
++  @MainActor
+   public func initWith(_ rootView: UIView) {
+     if RCTRunningInAppExtension() {
+       return
+     }
+ 
+-    self.rootView = rootView
+-    showSplashScreen()
+-    NotificationCenter.default.addObserver(self, selector: #selector(onAppReady), name: Notification.Name("RCTContentDidAppearNotification"), object: nil)
++    if let rootView = rootView as? RCTRootView {
++        self.rootView[rootView.moduleName] = rootView
++    } else if let rootView = rootView as? RCTSurfaceHostingProxyRootView {
++        self.rootView[rootView.moduleName] = rootView
++    }
++    
++    showSplashScreen(rootView: rootView)
+   }
+ 
+   @objc private func onAppReady() {
+     if !preventAutoHideCalled {
+-      hide()
++      DispatchQueue.main.async {
++        self.rootView.keys.forEach { moduleName in
++          self.hide(moduleName: moduleName)
++        }
++      }
+     }
+   }
+ 
+-  func hide() {
++  func hide(moduleName: String?) {
+     if RCTRunningInAppExtension() {
+       return
+     }
+ 
+     DispatchQueue.main.async { [weak self] in
+-      guard let self, let rootView, isLoadingViewVisible() else {
++      guard let self, let rootView = self.rootView[moduleName ?? "main"] else {
+         return
+       }
++        
++      var loadingView: UIView?
++          
++      if let rootView = rootView as? RCTSurfaceHostingProxyRootView {
++        loadingView = rootView.loadingView
++      } else if let rootView = rootView as? RCTRootView {
++        loadingView = rootView.subviews.first(where: { subView in
++          subView.accessibilityIdentifier == self.splashScreenIdentifier
++        })
++      }
++          
++      guard let loadingView else {
++        return
++      }
++        
++      if loadingView.isHidden {
++        return
++      }
++        
+       let duration = options.duration / 1000
+       if options.fade {
+         UIView.transition(with: rootView, duration: duration, options: .transitionCrossDissolve) {
+-          self.loadingView?.isHidden = true
++          loadingView.isHidden = true
+         } completion: { _ in
+-          self.loadingView?.removeFromSuperview()
+-          self.loadingView = nil
++          loadingView.removeFromSuperview()
++          
+         }
+       } else {
+-        loadingView?.isHidden = true
+-        loadingView?.removeFromSuperview()
+-        loadingView = nil
++        loadingView.isHidden = true
++        loadingView.removeFromSuperview()
+       }
+     }
+   }
+@@ -56,40 +88,36 @@ public class SplashScreenManager: NSObject, RCTReloadListener {
+     self.options = options
+   }
+ 
+-  private func showSplashScreen() {
++  private func showSplashScreen(rootView: UIView) {
+     let splashScreenFilename = Bundle.main.object(forInfoDictionaryKey: "UILaunchStoryboardName") as? String ?? "SplashScreen"
+     if let vc = UIStoryboard(name: splashScreenFilename, bundle: nil).instantiateInitialViewController() {
+-      loadingView = vc.view
+-      loadingView?.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+     
+-      if let bounds = self.rootView?.bounds {
+-        loadingView?.frame = bounds
+-        loadingView?.center = CGPoint(x: bounds.midX, y: bounds.midY)
+-      }
+-      loadingView?.isHidden = false
++    guard let loadingView = vc.view else {
++      return
++    }
++    loadingView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
++    loadingView.frame = rootView.bounds
++    loadingView.center = CGPoint(x: rootView.bounds.midX, y: rootView.bounds.midY)
++    loadingView.isHidden = false
++        
+ #if RCT_NEW_ARCH_ENABLED
+-      if let hostView = rootView as? RCTSurfaceHostingProxyRootView, let loadingView {
++      if let hostView = rootView as? RCTSurfaceHostingProxyRootView {
+         hostView.disableActivityIndicatorAutoHide(true)
+         hostView.loadingView = loadingView
+       }
+ #else
+-      if let loadingView {
+-        self.rootView?.addSubview(loadingView)
+-      }
++      loadingView.accessibilityIdentifier = splashScreenIdentifier
++      rootView.addSubview(loadingView)
+ #endif
+     }
+   }
+ 
+   public func didReceiveReloadCommand() {
+-    showSplashScreen()
+-  }
+-
+-  private func isLoadingViewVisible() -> Bool {
+-    guard let loadingView else {
+-      return false
+-    }
+-
+-    return !loadingView.isHidden
++      DispatchQueue.main.async {
++        self.rootView.forEach { (moduleName: String, rootView: UIView) in
++          self.showSplashScreen(rootView: rootView)
++        }
++      }
+   }
+ 
+   func removeObservers() {
+diff --git a/node_modules/expo-splash-screen/ios/SplashScreenModule.swift b/node_modules/expo-splash-screen/ios/SplashScreenModule.swift
+index f7baf4d..5b3fe77 100644
+--- a/node_modules/expo-splash-screen/ios/SplashScreenModule.swift
++++ b/node_modules/expo-splash-screen/ios/SplashScreenModule.swift
+@@ -10,17 +10,17 @@ public class SplashScreenModule: Module {
+       SplashScreenManager.shared.setOptions(options: options)
+     }
+ 
+-    Function("hide") {
+-      SplashScreenManager.shared.hide()
++    Function("hide") { (moduleName: String?) in
++      SplashScreenManager.shared.hide(moduleName: moduleName)
+     }
+ 
+-    AsyncFunction("hideAsync") {
+-      SplashScreenManager.shared.hide()
++    AsyncFunction("hideAsync") { (moduleName: String?) in
++      SplashScreenManager.shared.hide(moduleName: moduleName)
+     }
+ 
+     AsyncFunction("internalMaybeHideAsync") {
+       if !userControlledAutoHideEnabled {
+-        SplashScreenManager.shared.hide()
++        SplashScreenManager.shared.hide(moduleName: "main")
+       }
+     }
+ 
+diff --git a/node_modules/expo-splash-screen/src/SplashScreen.types.ts b/node_modules/expo-splash-screen/src/SplashScreen.types.ts
+index 3cc79ec..d0f5d96 100644
+--- a/node_modules/expo-splash-screen/src/SplashScreen.types.ts
++++ b/node_modules/expo-splash-screen/src/SplashScreen.types.ts
+@@ -17,7 +17,7 @@ export type SplashScreenOptions = {
+ export interface SplashScreenNativeModule extends NativeModule {
+   setOptions: (options: SplashScreenOptions) => void;
+   preventAutoHideAsync: () => Promise<boolean>;
+-  hide: () => void;
++  hide: (moduleName?: string) => void;
+   hideAsync: () => Promise<void>;
+   // @private
+   _internal_maybeHideAsync: () => Promise<void>;
+diff --git a/node_modules/expo-splash-screen/src/index.native.ts b/node_modules/expo-splash-screen/src/index.native.ts
+index 4f46ea4..cfe8716 100644
+--- a/node_modules/expo-splash-screen/src/index.native.ts
++++ b/node_modules/expo-splash-screen/src/index.native.ts
+@@ -2,6 +2,7 @@ import { isRunningInExpoGo } from 'expo';
+ import { requireOptionalNativeModule } from 'expo-modules-core';
+ 
+ import { SplashScreenNativeModule, SplashScreenOptions } from './SplashScreen.types';
++import { Platform } from 'react-native';
+ 
+ const SplashModule = requireOptionalNativeModule<SplashScreenNativeModule>('ExpoSplashScreen');
+ 
+@@ -20,16 +21,21 @@ export function setOptions(options: SplashScreenOptions) {
+   SplashModule.setOptions(options);
+ }
+ 
+-export function hide() {
++export function hide(moduleName?: string) {
+   if (!SplashModule) {
+     return;
+   }
+ 
++  if (Platform.OS === 'ios') {
++    SplashModule.hide(moduleName);
++    return;
++  }
++
+   SplashModule.hide();
+ }
+ 
+-export async function hideAsync(): Promise<void> {
+-  hide();
++export async function hideAsync(moduleName?: string): Promise<void> {
++  hide(moduleName);
+ }
+ 
+ export async function preventAutoHideAsync() {
+diff --git a/node_modules/expo-splash-screen/src/index.ts b/node_modules/expo-splash-screen/src/index.ts
+index cba1f02..8c236d8 100644
+--- a/node_modules/expo-splash-screen/src/index.ts
++++ b/node_modules/expo-splash-screen/src/index.ts
+@@ -37,12 +37,12 @@ export function setOptions(options: SplashScreenOptions): void {}
+  * to display when you hide the splash screen, or you may see a blank screen briefly. See the
+  * ["Usage"](#usage) section for an example.
+  */
+-export function hide(): void {}
++export function hide(moduleName?: string): void {}
+ 
+ /**
+  * Hides the native splash screen immediately. This method is provided for backwards compatability. See the
+  * ["Usage"](#usage) section for an example.
+  */
+-export async function hideAsync(): Promise<void> {}
++export async function hideAsync(moduleName?: string): Promise<void> {}
+ 
+ export { SplashScreenOptions };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4085,13 +4085,13 @@ negotiator@~0.6.4:
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz"
   integrity sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==
 
-nitrogen@^0.33.2:
-  version "0.33.2"
-  resolved "https://registry.yarnpkg.com/nitrogen/-/nitrogen-0.33.2.tgz#22ae1b21656034c91885e091db6a57e2383e55a7"
-  integrity sha512-1fypSMqDU2vnRDmI8PYH0F3/ICLgRqsKCtOyNSMX7rQsG9D7G6zINvZH0Vk0unjzTude5SN8XNFO5im4LrGCvQ==
+nitrogen@^0.33.7:
+  version "0.33.7"
+  resolved "https://registry.yarnpkg.com/nitrogen/-/nitrogen-0.33.7.tgz#b2b01bc1a49faf68b477b640ac71e60900ad799c"
+  integrity sha512-ize7GC7ggNUdAWeSjEEDZU0M2kwKWY66hJGqjJWaLea0EEdYHtFD+qUo5owIRZaORtx90oNtKC7WVKYvXAWPgQ==
   dependencies:
     chalk "^5.3.0"
-    react-native-nitro-modules "^0.33.2"
+    react-native-nitro-modules "^0.33.7"
     ts-morph "^27.0.0"
     yargs "^18.0.0"
     zod "^4.0.5"
@@ -4426,10 +4426,10 @@ react-native-config@^1.6.1:
   resolved "https://registry.yarnpkg.com/react-native-config/-/react-native-config-1.6.1.tgz#f8428829fda74384484d773fe36820159c559159"
   integrity sha512-HvKtxr6/Tq3iMdFx5REYZsjCtPi0RxQOMCs15+DqrUPTNFtWHuEuh+zw7fJp+dmuO79YMfdtlsPWIGTHtaXwjg==
 
-react-native-nitro-modules@^0.33.2:
-  version "0.33.2"
-  resolved "https://registry.yarnpkg.com/react-native-nitro-modules/-/react-native-nitro-modules-0.33.2.tgz#7b1fb3c945779a238e7130448ba415f523a61e9b"
-  integrity sha512-ZlfOe6abODeHv/eZf8PxeSkrxIUhEKha6jaAAA9oXy7I6VPr7Ff4dUsAq3cyF3kX0L6qt2Dh9nzD2NdSsDwGpA==
+react-native-nitro-modules@^0.33.7:
+  version "0.33.7"
+  resolved "https://registry.yarnpkg.com/react-native-nitro-modules/-/react-native-nitro-modules-0.33.7.tgz#eb8104cc19e4242ab325666af24ea6ffc8b1539e"
+  integrity sha512-WepMobWe4j1Ae5GQ5RxYGBdBpJBwzP6zaOxJ7r6nhbY5iyl01DL3Gsh4gk8edzNFRuAh1rvXDAHIipq8SahxeQ==
 
 react-native-safe-area-context@^5.5.2:
   version "5.6.1"


### PR DESCRIPTION
This PR brings:
- nitrogen and react-native-nitrogen 0.33.7
- expo-splash-screen 31.0.13 patch
- fix: Android Auto example app crashing
- fix: CarPlay example app not starting timer