### PR TITLE
possible fix for a crash

### DIFF
--- a/packages/react-native-autoplay/ios/templates/MapTemplate.swift
+++ b/packages/react-native-autoplay/ios/templates/MapTemplate.swift
@@ -81,7 +81,11 @@ class MapTemplate: AutoPlayHeaderProviding,
     }
 
     func parseMapButtons(mapButtons: [NitroMapButton]) -> [CPMapButton] {
-        return mapButtons.map { button in
+        return mapButtons.map { [weak self] button in
+            // Capture onPress callback directly to avoid issues with button lifecycle
+            let onPress = button.onPress
+            let buttonType = button.type
+            
             if let glyphImage = button.image.glyphImage,
                 let icon = SymbolFont.imageFromNitroImage(
                     image: glyphImage,
@@ -89,12 +93,12 @@ class MapTemplate: AutoPlayHeaderProviding,
                     traitCollection: SceneStore.getRootTraitCollection()
                 )
             {
-                return CPMapButton(image: icon) { _ in
-                    if button.type == .pan {
-                        self.onPanButtonPress()
+                return CPMapButton(image: icon) { [weak self] _ in
+                    if buttonType == .pan {
+                        self?.onPanButtonPress()
                         return
                     }
-                    button.onPress?()
+                    onPress?()
                 }
             }
             if let assetImage = button.image.assetImage,
@@ -103,21 +107,21 @@ class MapTemplate: AutoPlayHeaderProviding,
                     traitCollection: SceneStore.getRootTraitCollection()
                 )
             {
-                return CPMapButton(image: icon) { _ in
-                    if button.type == .pan {
-                        self.onPanButtonPress()
+                return CPMapButton(image: icon) { [weak self] _ in
+                    if buttonType == .pan {
+                        self?.onPanButtonPress()
                         return
                     }
-                    button.onPress?()
+                    onPress?()
                 }
             }
 
-            return CPMapButton { _ in
-                if button.type == .pan {
-                    self.onPanButtonPress()
+            return CPMapButton { [weak self] _ in
+                if buttonType == .pan {
+                    self?.onPanButtonPress()
                     return
                 }
-                button.onPress?()
+                onPress?()
             }
         }
 
@@ -141,12 +145,12 @@ class MapTemplate: AutoPlayHeaderProviding,
                 self.template.dismissPanningInterface(animated: true)
             }
 
-            let mapButtons =
-                mapButtons?.filter { button in
+            let filteredMapButtons =
+                self.mapButtons?.filter { button in
                     button.type != .pan
                 } ?? []
 
-            template.mapButtons = parseMapButtons(mapButtons: mapButtons)
+            template.mapButtons = parseMapButtons(mapButtons: filteredMapButtons)
 
             return
         }


### PR DESCRIPTION
We got this crash on Sentry:
```
0   ABRP                            0x200a10878         closure in MapTemplate.parseMapButtons
1   ABRP                            0x200a0fe80         MapTemplate.parseMapButtons
2   ABRP                            0x200a1115c         MapTemplate._invalidate
3   ABRP                            0x200a3b920         closure in RootModule.withAutoPlayTemplate<T>
4   ABRP                            0x200a03ad4         HybridMapTemplate
```

According to an AI analysis this would be the right fix. But I'm not too familiar with native iOS code, so @g4rb4g3 could you please have a look?