### PR TITLE
fix: trip selector showing invalid header buttons

### DIFF
--- a/packages/react-native-autoplay/ios/hybrid/HybridAutoPlay.swift
+++ b/packages/react-native-autoplay/ios/hybrid/HybridAutoPlay.swift
@@ -270,7 +270,7 @@ class HybridAutoPlay: HybridAutoPlaySpec {
                         templateId: templateId
                     )
 
-                    guard var template = template as? AutoPlayHeaderProviding
+                    guard let template = template as? AutoPlayHeaderProviding
                     else {
                         throw AutoPlayError.invalidTemplateType(
                             "\(templateId) does not support header actions"
@@ -278,7 +278,7 @@ class HybridAutoPlay: HybridAutoPlaySpec {
                     }
 
                     template.barButtons = headerActions
-                    setBarButtons(template: template.getTemplate(), barButtons: headerActions)
+                    template.invalidate()
                 }
             }
         }


### PR DESCRIPTION
This PR fixes a bug that the trip selector did not show a back button but the templates header buttons in case `mapTemplate.setHeaderActions` was called after the trip selector has been called.

<img width="865" height="489" alt="image" src="https://github.com/user-attachments/assets/7dc61a8d-871a-4d87-9950-573cfba904f1" />
