### PR TITLE
fix: force unwrap causing crash

### DIFF
--- a/packages/react-native-autoplay/ios/scenes/HeadUnitSceneDelegate.swift
+++ b/packages/react-native-autoplay/ios/scenes/HeadUnitSceneDelegate.swift
@@ -54,18 +54,27 @@ class HeadUnitSceneDelegate: AutoPlayScene, CPTemplateApplicationSceneDelegate {
 
     func templateApplicationScene(
         _ templateApplicationScene: CPTemplateApplicationScene,
-        didDisconnectInterfaceController interfaceController:
-            CPInterfaceController
+        didDisconnect interfaceController: CPInterfaceController,
+        from window: CPWindow
     ) {
-        HybridAutoPlay.emit(event: .diddisconnect)
-        
         if let mapTemplate = try? templateStore.getTemplate(
             templateId: SceneStore.rootModuleName
         ) as? MapTemplate {
             mapTemplate.stopNavigation()
         }
-        
+
         disconnect()
+
+        HybridAutoPlay.emit(event: .diddisconnect)
+    }
+
+    func templateApplicationScene(
+        _ templateApplicationScene: CPTemplateApplicationScene,
+        didDisconnectInterfaceController interfaceController:
+            CPInterfaceController
+    ) {
+        disconnect()
+        HybridAutoPlay.emit(event: .diddisconnect)
     }
 
     func sceneWillResignActive(_ scene: UIScene) {

--- a/packages/react-native-autoplay/ios/scenes/SceneStore.swift
+++ b/packages/react-native-autoplay/ios/scenes/SceneStore.swift
@@ -84,7 +84,7 @@ class SceneStore {
         return store[SceneStore.rootModuleName]
     }
 
-    static func getRootTraitCollection() -> UITraitCollection {
-        return store[SceneStore.rootModuleName]!.traitCollection
+    static func getRootTraitCollection() -> UITraitCollection? {
+        return store[SceneStore.rootModuleName]?.traitCollection
     }
 }

--- a/packages/react-native-autoplay/ios/templates/AutoPlayTemplate.swift
+++ b/packages/react-native-autoplay/ios/templates/AutoPlayTemplate.swift
@@ -42,10 +42,14 @@ class AutoPlayHeaderProviding: AutoPlayTemplate {
 func setBarButtons(template: CPTemplate, barButtons: [NitroAction]?) {
     guard let template = template as? CPBarButtonProviding else { return }
 
+    guard let traitCollection = SceneStore.getRootTraitCollection() else {
+        return
+    }
+
     if let headerActions = barButtons {
         let parsedActions = Parser.parseHeaderActions(
             headerActions: headerActions,
-            traitCollection: SceneStore.getRootTraitCollection()
+            traitCollection: traitCollection
         )
 
         template.backButton = parsedActions.backButton

--- a/packages/react-native-autoplay/ios/templates/GridTemplate.swift
+++ b/packages/react-native-autoplay/ios/templates/GridTemplate.swift
@@ -24,17 +24,17 @@ class GridTemplate: AutoPlayHeaderProviding {
     init(config: GridTemplateConfig) {
         self.config = config
         buttons = config.buttons
-        
+
         template = CPGridTemplate(
             title: Parser.parseText(text: config.title),
             gridButtons: GridTemplate.parseButtons(buttons: buttons),
             id: config.id
         )
-                
+
         super.init()
-        
+
         barButtons = config.headerActions
-        
+
     }
 
     static func parseButtons(buttons: [NitroGridButton]) -> [CPGridButton] {
@@ -47,7 +47,9 @@ class GridTemplate: AutoPlayHeaderProviding {
             gridButtonHeight = 44
         }
 
-        let traitCollection = SceneStore.getRootTraitCollection()
+        guard let traitCollection = SceneStore.getRootTraitCollection() else {
+            return []
+        }
 
         return buttons.compactMap { button in
             var image: UIImage?

--- a/packages/react-native-autoplay/ios/templates/InformationTemplate.swift
+++ b/packages/react-native-autoplay/ios/templates/InformationTemplate.swift
@@ -23,7 +23,7 @@ class InformationTemplate: AutoPlayHeaderProviding {
 
     init(config: InformationTemplateConfig) {
         self.config = config
-        
+
         section = config.section
 
         template = CPInformationTemplate(
@@ -33,9 +33,9 @@ class InformationTemplate: AutoPlayHeaderProviding {
             actions: Parser.parseInformationActions(actions: config.actions),
             id: config.id
         )
-        
-        super.init();
-        
+
+        super.init()
+
         barButtons = config.headerActions
     }
 

--- a/packages/react-native-autoplay/ios/templates/ListTemplate.swift
+++ b/packages/react-native-autoplay/ios/templates/ListTemplate.swift
@@ -23,7 +23,7 @@ class ListTemplate: AutoPlayHeaderProviding {
 
     init(config: ListTemplateConfig) {
         self.config = config
-        
+
         sections = config.sections
 
         template = CPListTemplate(
@@ -32,9 +32,9 @@ class ListTemplate: AutoPlayHeaderProviding {
             assistantCellConfiguration: nil,
             id: config.id
         )
-        
+
         super.init()
-        
+
         barButtons = config.headerActions
     }
 
@@ -42,11 +42,15 @@ class ListTemplate: AutoPlayHeaderProviding {
     override func _invalidate() {
         setBarButtons(template: template, barButtons: barButtons)
 
+        guard let traitCollection = SceneStore.getRootTraitCollection() else {
+            return
+        }
+
         template.updateSections(
             Parser.parseSections(
                 sections: sections,
                 updateSection: self.updateSection(section:sectionIndex:),
-                traitCollection: SceneStore.getRootTraitCollection()
+                traitCollection: traitCollection
             )
         )
     }

--- a/packages/react-native-autoplay/ios/templates/MapTemplate.swift
+++ b/packages/react-native-autoplay/ios/templates/MapTemplate.swift
@@ -45,10 +45,10 @@ class MapTemplate: AutoPlayHeaderProviding,
 
     init(config: MapTemplateConfig) {
         self.config = config
-        
+
         mapButtons = config.mapButtons
         visibleTravelEstimate = config.visibleTravelEstimate
-        
+
         template = CPMapTemplate(id: config.id)
 
         if let initialProperties = SceneStore.getRootScene()?.initialProperties,
@@ -81,12 +81,16 @@ class MapTemplate: AutoPlayHeaderProviding,
     }
 
     func parseMapButtons(mapButtons: [NitroMapButton]) -> [CPMapButton] {
+        guard let traitCollection = SceneStore.getRootTraitCollection() else {
+            return []
+        }
+
         return mapButtons.map { button in
             if let glyphImage = button.image.glyphImage,
                 let icon = SymbolFont.imageFromNitroImage(
                     image: glyphImage,
                     size: CPButtonMaximumImageSize.height,
-                    traitCollection: SceneStore.getRootTraitCollection()
+                    traitCollection: traitCollection
                 )
             {
                 return CPMapButton(image: icon) { _ in
@@ -100,7 +104,7 @@ class MapTemplate: AutoPlayHeaderProviding,
             if let assetImage = button.image.assetImage,
                 let icon = Parser.parseAssetImage(
                     assetImage: assetImage,
-                    traitCollection: SceneStore.getRootTraitCollection()
+                    traitCollection: traitCollection
                 )
             {
                 return CPMapButton(image: icon) { _ in
@@ -180,7 +184,10 @@ class MapTemplate: AutoPlayHeaderProviding,
 
     @MainActor
     override func traitCollectionDidChange() {
-        let traitCollection = SceneStore.getRootTraitCollection()
+        guard let traitCollection = SceneStore.getRootTraitCollection() else {
+            return
+        }
+
         let isDark = traitCollection.userInterfaceStyle == .dark
 
         config.onAppearanceDidChange?(
@@ -354,6 +361,10 @@ class MapTemplate: AutoPlayHeaderProviding,
             return
         }
 
+        guard let traitCollection = SceneStore.getRootTraitCollection() else {
+            return
+        }
+
         guard let title = Parser.parseText(text: alertConfig.title) else { return }
         let subtitle = alertConfig.subtitle.flatMap { subtitle in
             [Parser.parseText(text: subtitle)].compactMap { $0 }
@@ -361,7 +372,7 @@ class MapTemplate: AutoPlayHeaderProviding,
 
         let image = Parser.parseNitroImage(
             image: alertConfig.image,
-            traitCollection: SceneStore.getRootTraitCollection()
+            traitCollection: traitCollection
         )
 
         let style = Parser.parseActionAlertStyle(
@@ -599,6 +610,10 @@ class MapTemplate: AutoPlayHeaderProviding,
     func updateManeuvers(messageManeuver: NitroMessageManeuver) {
         guard let navigationSession = navigationSession else { return }
 
+        guard let traitCollection = SceneStore.getRootTraitCollection() else {
+            return
+        }
+
         let color = messageManeuver.cardBackgroundColor
         let cardBackgroundColor = Parser.parseColor(color: color)
 
@@ -615,7 +630,7 @@ class MapTemplate: AutoPlayHeaderProviding,
 
         if let symbolImage = Parser.parseNitroImage(
             image: messageManeuver.image,
-            traitCollection: SceneStore.getRootTraitCollection()
+            traitCollection: traitCollection
         ) {
             maneuver.symbolImage = symbolImage
         }
@@ -632,6 +647,10 @@ class MapTemplate: AutoPlayHeaderProviding,
 
         if maneuvers.isEmpty {
             navigationSession.upcomingManeuvers = []
+            return
+        }
+
+        guard let traitCollection = SceneStore.getRootTraitCollection() else {
             return
         }
 
@@ -674,7 +693,7 @@ class MapTemplate: AutoPlayHeaderProviding,
 
             let maneuver = Parser.parseManeuver(
                 nitroManeuver: nitroManeuver,
-                traitCollection: SceneStore.getRootTraitCollection()
+                traitCollection: traitCollection
             )
             upcomingManeuvers.append(maneuver)
         }
@@ -686,7 +705,7 @@ class MapTemplate: AutoPlayHeaderProviding,
                         // CarPlay has a limitation of 120x18 for the symbolImage on secondaryManeuver that shows lanes only
                         let secondarySymbolImage = Parser.imageFromLanes(
                             laneImages: laneImages.prefix(Int(120 / 18)),
-                            traitCollection: SceneStore.getRootTraitCollection()
+                            traitCollection: traitCollection
                         )
 
                         let secondaryManeuver = CPManeuver(

--- a/packages/react-native-autoplay/ios/templates/SearchTemplate.swift
+++ b/packages/react-native-autoplay/ios/templates/SearchTemplate.swift
@@ -28,7 +28,7 @@ class SearchTemplate: AutoPlayTemplate, CPSearchTemplateDelegate {
     init(config: SearchTemplateConfig) {
         self.config = config
         results = config.results
-        
+
         template = CPSearchTemplate(id: config.id)
     }
 
@@ -49,9 +49,13 @@ class SearchTemplate: AutoPlayTemplate, CPSearchTemplateDelegate {
             return
         }
 
+        guard let traitCollection = SceneStore.getRootTraitCollection() else {
+            return
+        }
+
         let listItems = Parser.parseSearchResults(
             section: results,
-            traitCollection: SceneStore.getRootTraitCollection()
+            traitCollection: traitCollection
         )
         completionHandler(listItems)
 


### PR DESCRIPTION
This PR should fix the crash related to the root trait collection.
In case we do not have a root trait collection we can assume CarPlay isn't connected anymore and skip whatever we tried to do.