### PR TITLE
prevent crash on disconnect, when scene is removed and code on js side still executed

### DIFF
--- a/packages/react-native-autoplay/ios/hybrid/HybridAutoPlay.swift
+++ b/packages/react-native-autoplay/ios/hybrid/HybridAutoPlay.swift
@@ -147,7 +147,7 @@ class HybridAutoPlay: HybridAutoPlaySpec {
         -> NitroModules.Promise<Void>
     {
         return Promise.async {
-            return try await RootModule.withSceneAndInterfaceController {
+            try await RootModule.withSceneAndInterfaceController {
                 scene,
                 interfaceController in
 
@@ -196,7 +196,7 @@ class HybridAutoPlay: HybridAutoPlaySpec {
 
     func popTemplate(animate: Bool?) throws -> NitroModules.Promise<Void> {
         return Promise.async {
-            return try await RootModule.withInterfaceController {
+            try await RootModule.withInterfaceController {
                 interfaceController in
 
                 if try await interfaceController.dismissTemplate(
@@ -240,7 +240,7 @@ class HybridAutoPlay: HybridAutoPlaySpec {
         Void
     > {
         return Promise.async {
-            return try await RootModule.withInterfaceController {
+            try await RootModule.withInterfaceController {
                 interfaceController in
 
                 let _ = try await interfaceController.dismissTemplate(

--- a/packages/react-native-autoplay/ios/scenes/AutoPlayScene.swift
+++ b/packages/react-native-autoplay/ios/scenes/AutoPlayScene.swift
@@ -53,10 +53,9 @@ class AutoPlayScene: UIResponder {
     }
 
     func disconnect() {
-        isConnected = false
-
         NitroSurface.stop(self.window?.rootViewController?.view)
         self.window = nil
+        isConnected = false
 
         templateStore.disconnect()
         SceneStore.removeScene(moduleName: moduleName)

--- a/packages/react-native-autoplay/ios/scenes/AutoPlayScene.swift
+++ b/packages/react-native-autoplay/ios/scenes/AutoPlayScene.swift
@@ -53,11 +53,13 @@ class AutoPlayScene: UIResponder {
     }
 
     func disconnect() {
-        SceneStore.removeScene(moduleName: moduleName)
         isConnected = false
-        templateStore.disconnect()
+
         NitroSurface.stop(self.window?.rootViewController?.view)
         self.window = nil
+
+        templateStore.disconnect()
+        SceneStore.removeScene(moduleName: moduleName)
     }
 
     func setState(state: VisibilityState) {

--- a/packages/react-native-autoplay/ios/scenes/AutoPlayScene.swift
+++ b/packages/react-native-autoplay/ios/scenes/AutoPlayScene.swift
@@ -53,12 +53,11 @@ class AutoPlayScene: UIResponder {
     }
 
     func disconnect() {
+        SceneStore.removeScene(moduleName: moduleName)
+        isConnected = false
+        templateStore.disconnect()
         NitroSurface.stop(self.window?.rootViewController?.view)
         self.window = nil
-        isConnected = false
-
-        templateStore.disconnect()
-        SceneStore.removeScene(moduleName: moduleName)
     }
 
     func setState(state: VisibilityState) {

--- a/packages/react-native-autoplay/ios/utils/RootModule.swift
+++ b/packages/react-native-autoplay/ios/utils/RootModule.swift
@@ -16,9 +16,7 @@ class RootModule {
                 moduleName: SceneStore.rootModuleName
             )
         else {
-            throw AutoPlayError.sceneNotFound(
-                "operation failed, \(SceneStore.rootModuleName) scene not found"
-            )
+            return
         }
 
         try action(scene)
@@ -77,9 +75,7 @@ class RootModule {
                 moduleName: SceneStore.rootModuleName
             )
         else {
-            throw AutoPlayError.sceneNotFound(
-                "operation failed, \(SceneStore.rootModuleName) scene not found"
-            )
+            return
         }
 
         return try await action(scene)

--- a/packages/react-native-autoplay/ios/utils/RootModule.swift
+++ b/packages/react-native-autoplay/ios/utils/RootModule.swift
@@ -69,13 +69,13 @@ class RootModule {
     static func withScene<T>(
         perform action:
             @escaping (AutoPlayScene) async throws -> T
-    ) async throws -> T {
+    ) async throws -> T? {
         guard
             let scene = SceneStore.getScene(
                 moduleName: SceneStore.rootModuleName
             )
         else {
-            return
+            return nil
         }
 
         return try await action(scene)
@@ -86,7 +86,7 @@ class RootModule {
         perform action:
             @escaping (AutoPlayScene, AutoPlayInterfaceController) async throws
             -> T
-    ) async throws -> T {
+    ) async throws -> T? {
         return try await withScene { scene in
             guard let interfaceController = scene.interfaceController else {
                 throw AutoPlayError.interfaceControllerNotFound(
@@ -102,7 +102,7 @@ class RootModule {
     static func withInterfaceController<T>(
         perform action:
             @escaping (AutoPlayInterfaceController) async throws -> T
-    ) async throws -> T {
+    ) async throws -> T? {
         try await withSceneAndInterfaceController { _, interfaceController in
             try await action(interfaceController)
         }

--- a/packages/react-native-autoplay/package.json
+++ b/packages/react-native-autoplay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iternio/react-native-auto-play",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Android Auto and Apple CarPlay for react-native",
   "main": "lib/index",
   "module": "lib/index",

--- a/packages/react-native-autoplay/package.json
+++ b/packages/react-native-autoplay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iternio/react-native-auto-play",
-  "version": "0.2.4",
+  "version": "0.2.5-alpha",
   "description": "Android Auto and Apple CarPlay for react-native",
   "main": "lib/index",
   "module": "lib/index",

--- a/packages/react-native-autoplay/src/templates/GridTemplate.ts
+++ b/packages/react-native-autoplay/src/templates/GridTemplate.ts
@@ -65,6 +65,8 @@ export class GridTemplate extends Template<GridTemplateConfig, HeaderActions<Gri
   }
 
   public updateGrid(buttons: Array<GridButton<GridTemplate>>) {
+    this.assertConnected();
+
     return HybridGridTemplate.updateGridTemplateButtons(
       this.id,
       NitroGridUtil.convert(this.template, buttons)

--- a/packages/react-native-autoplay/src/templates/InformationTemplate.ts
+++ b/packages/react-native-autoplay/src/templates/InformationTemplate.ts
@@ -115,6 +115,8 @@ export class InformationTemplate extends Template<
   }
 
   public updateItems(items?: InformationItems) {
+    this.assertConnected();
+
     const section = this.getSection(items);
     return HybridInformationTemplate.updateInformationTemplateSections(
       this.id,

--- a/packages/react-native-autoplay/src/templates/ListTemplate.ts
+++ b/packages/react-native-autoplay/src/templates/ListTemplate.ts
@@ -122,6 +122,8 @@ export class ListTemplate extends Template<ListTemplateConfig, HeaderActions<Lis
   }
 
   public updateSections(sections?: Section<ListTemplate>) {
+    this.assertConnected();
+
     return HybridListTemplate.updateListTemplateSections(
       this.id,
       NitroSectionUtil.convert(this.template, sections)

--- a/packages/react-native-autoplay/src/templates/MapTemplate.ts
+++ b/packages/react-native-autoplay/src/templates/MapTemplate.ts
@@ -197,11 +197,15 @@ export class MapTemplate extends Template<MapTemplateConfig, MapTemplateConfig['
   }
 
   public setMapButtons(mapButtons: MapTemplateConfig['mapButtons']) {
+    this.assertConnected();
+
     const buttons = NitroMapButton.convert(this.template, mapButtons);
     return HybridMapTemplate.setTemplateMapButtons(this.id, buttons);
   }
 
   public override setHeaderActions(headerActions: MapTemplateConfig['headerActions']) {
+    this.assertConnected();
+
     const nitroActions = NitroActionUtil.convert(this.template, headerActions);
     return HybridAutoPlay.setTemplateHeaderActions(this.id, nitroActions);
   }
@@ -212,14 +216,20 @@ export class MapTemplate extends Template<MapTemplateConfig, MapTemplateConfig['
    * @returns a callback to dismiss or update the navigation alert
    */
   public showAlert(alert: NavigationAlert) {
+    this.assertConnected();
+
     return HybridMapTemplate.showNavigationAlert(this.id, NitroAlertUtil.convert(alert));
   }
 
   public updateAlert(alertId: number, title: AutoText, subtitle?: AutoText) {
+    this.assertConnected();
+
     HybridMapTemplate.updateNavigationAlert(this.id, alertId, title, subtitle);
   }
 
   public dismissAlert(alertId: number) {
+    this.assertConnected();
+
     HybridMapTemplate.dismissNavigationAlert(this.id, alertId);
   }
 
@@ -249,6 +259,8 @@ export class MapTemplate extends Template<MapTemplateConfig, MapTemplateConfig['
      */
     mapButtons?: MapTemplateConfig['mapButtons'];
   }): TripSelectorCallback {
+    this.assertConnected();
+
     if (
       trips.length === 0 ||
       trips.some(
@@ -285,10 +297,14 @@ export class MapTemplate extends Template<MapTemplateConfig, MapTemplateConfig['
   }
 
   public hideTripSelector() {
+    this.assertConnected();
+
     HybridMapTemplate.hideTripSelector(this.id);
   }
 
   public updateVisibleTravelEstimate(visibleTravelEstimate: VisibleTravelEstimate) {
+    this.assertConnected();
+
     HybridMapTemplate.updateVisibleTravelEstimate(this.id, visibleTravelEstimate);
   }
 
@@ -297,6 +313,8 @@ export class MapTemplate extends Template<MapTemplateConfig, MapTemplateConfig['
    * @param steps all future steps, do not put in origin or passed steps
    */
   public updateTravelEstimates(steps: Array<TripPoint>) {
+    this.assertConnected();
+
     HybridMapTemplate.updateTravelEstimates(this.id, steps);
   }
 
@@ -306,6 +324,8 @@ export class MapTemplate extends Template<MapTemplateConfig, MapTemplateConfig['
    * @namespace iOS will update travelEstimates only when passing in maneuvers with the same id
    */
   public updateManeuvers(maneuvers: AutoManeuver) {
+    this.assertConnected();
+
     if (Array.isArray(maneuvers)) {
       const nitroManeuvers = maneuvers.reduce((acc, maneuver) => {
         if (maneuver == null) {
@@ -334,10 +354,14 @@ export class MapTemplate extends Template<MapTemplateConfig, MapTemplateConfig['
    * or use this to start a navigation session without asking the user
    */
   public startNavigation(trip: TripConfig) {
+    this.assertConnected();
+
     HybridMapTemplate.startNavigation(this.id, trip);
   }
 
   public stopNavigation() {
+    this.assertConnected();
+
     HybridMapTemplate.stopNavigation(this.id);
   }
 }

--- a/packages/react-native-autoplay/src/templates/MessageTemplate.ts
+++ b/packages/react-native-autoplay/src/templates/MessageTemplate.ts
@@ -74,8 +74,16 @@ export type MessageTemplateConfig = Omit<
 export class MessageTemplate {
   private template = this;
   public id = uuid.v4();
+  public isConnected = HybridAutoPlay.isConnected();
 
   constructor(config: MessageTemplateConfig) {
+    this.assertConnected();
+
+    const removeDisconnectListener = HybridAutoPlay.addListener('didDisconnect', () => {
+      this.isConnected = false;
+      removeDisconnectListener();
+    });
+
     const { headerActions, image, mapConfig, actions, ...rest } = config;
 
     const platformActions =
@@ -100,10 +108,18 @@ export class MessageTemplate {
     HybridMessageTemplate.createMessageTemplate(nitroConfig);
   }
 
+  public assertConnected() {
+    if (!this.isConnected) {
+      throw new Error(`Template '${this.id}' used after disconnect!`);
+    }
+  }
+
   /**
    * push this template on the stack and show it to the user
    */
   public push() {
+    this.assertConnected();
+
     return HybridAutoPlay.pushTemplate(this.id);
   }
 }

--- a/packages/react-native-autoplay/src/templates/SearchTemplate.ts
+++ b/packages/react-native-autoplay/src/templates/SearchTemplate.ts
@@ -87,6 +87,8 @@ export class SearchTemplate extends Template<SearchTemplateConfig, HeaderActions
   }
 
   public updateSearchResults(results?: SingleSection<SearchTemplate>) {
+    this.assertConnected();
+
     return HybridSearchTemplate.updateSearchResults(
       this.id,
       NitroSectionUtil.convert(this.template, results)?.at(0) ?? {

--- a/packages/react-native-autoplay/src/templates/SignInTemplate.ts
+++ b/packages/react-native-autoplay/src/templates/SignInTemplate.ts
@@ -97,6 +97,8 @@ export class SignInTemplate extends Template<
    * @returns A promise that resolves when the template is updated.
    */
   updateTemplate(updatedConfig: SignInTemplateUpdateConfig) {
+    this.assertConnected();
+
     const { headerActions, actions, ...rest } = updatedConfig;
     const nitroConfig: NitroSignInTemplateConfig & NitroTemplateConfig = {
       ...rest,

--- a/packages/react-native-autoplay/src/templates/Template.ts
+++ b/packages/react-native-autoplay/src/templates/Template.ts
@@ -74,17 +74,33 @@ export interface NitroBaseMapTemplateConfig extends TemplateConfig {
 
 export class Template<TemplateConfigType, ActionsType> {
   public id!: string;
+  public isConnected = HybridAutoPlay.isConnected();
 
   constructor(config: TemplateConfig & TemplateConfigType) {
+    this.assertConnected();
+
     // templates that render on a surface provide their own id, others use a auto generated one
     this.id =
       'id' in config && config.id != null && typeof config.id === 'string' ? config.id : uuid.v4();
+
+    const removeDisconnectListener = HybridAutoPlay.addListener('didDisconnect', () => {
+      this.isConnected = false;
+      removeDisconnectListener();
+    });
+  }
+
+  public assertConnected() {
+    if (!this.isConnected) {
+      throw new Error(`Template '${this.id}' used after disconnect!`);
+    }
   }
 
   /**
    * set as root template on the stack
    */
   public setRootTemplate() {
+    this.assertConnected();
+
     return HybridAutoPlay.setRootTemplate(this.id);
   }
 
@@ -92,6 +108,8 @@ export class Template<TemplateConfigType, ActionsType> {
    * push this template on the stack and show it to the user
    */
   public push() {
+    this.assertConnected();
+
     return HybridAutoPlay.pushTemplate(this.id);
   }
 
@@ -99,10 +117,14 @@ export class Template<TemplateConfigType, ActionsType> {
    * remove all templates above this one from the stack
    */
   public popTo() {
+    this.assertConnected();
+
     return HybridAutoPlay.popToTemplate(this.id);
   }
 
   public setHeaderActions<T>(headerActions?: ActionsType) {
+    this.assertConnected();
+
     const nitroActions = NitroActionUtil.convert(
       this as unknown as T,
       headerActions as HeaderActions<T>


### PR DESCRIPTION
When CP was disconnected, the react code still executed and called native functions, but the scene was already destroyed, so it crashed with error `operation failed, AutoPlayRootScene scene not found`