### PR TITLE
Use a ref for useMapTemplate

### DIFF
--- a/apps/example/src/AutoPlay.tsx
+++ b/apps/example/src/AutoPlay.tsx
@@ -56,7 +56,7 @@ const AutoPlayRoot = (props: RootComponentInitialProps) => {
       return;
     }
 
-    mapTemplate?.showAlert({
+    mapTemplate.current?.showAlert({
       durationMs: 10 * 1000,
       id: 1,
       primaryAction: {
@@ -83,7 +83,7 @@ const AutoPlayRoot = (props: RootComponentInitialProps) => {
       startAppListening({
         actionCreator: actionStartNavigation,
         effect: (action, { dispatch }) => {
-          if (mapTemplate == null) {
+          if (mapTemplate.current == null) {
             return;
           }
 
@@ -98,9 +98,9 @@ const AutoPlayRoot = (props: RootComponentInitialProps) => {
           }
 
           dispatch(setSelectedTrip({ routeId, tripId }));
-          mapTemplate.startNavigation({ id: tripId, routeChoice });
-          onTripStarted(tripId, routeId, mapTemplate);
-          updateTripEstimates(mapTemplate, 'initial');
+          mapTemplate.current.startNavigation({ id: tripId, routeChoice });
+          onTripStarted(tripId, routeId, mapTemplate.current);
+          updateTripEstimates(mapTemplate.current, 'initial');
         },
       })
     );
@@ -109,10 +109,10 @@ const AutoPlayRoot = (props: RootComponentInitialProps) => {
       startAppListening({
         actionCreator: actionStopNavigation,
         effect: () => {
-          if (mapTemplate == null) {
+          if (mapTemplate.current == null) {
             return;
           }
-          onTripFinished(mapTemplate);
+          onTripFinished(mapTemplate.current);
         },
       })
     );
@@ -121,14 +121,14 @@ const AutoPlayRoot = (props: RootComponentInitialProps) => {
       startAppListening({
         actionCreator: actionShowAlert,
         effect: (action) => {
-          if (mapTemplate == null) {
+          if (mapTemplate.current == null) {
             return;
           }
           const prio = action.payload;
           let timer: number | null = null;
           const id = Date.now();
 
-          mapTemplate.showAlert({
+          mapTemplate.current.showAlert({
             id,
             title: { text: `Alert ${id}` },
             subtitle: { text: `Prio: ${prio}` },
@@ -144,7 +144,7 @@ const AutoPlayRoot = (props: RootComponentInitialProps) => {
             },
             onWillShow: () => {
               timer = setTimeout(() => {
-                mapTemplate.updateAlert(id, { text: `Alert ${Date.now()}` }, undefined);
+                mapTemplate.current?.updateAlert(id, { text: `Alert ${Date.now()}` }, undefined);
               }, 5000);
             },
           });

--- a/apps/example/src/AutoPlay.tsx
+++ b/apps/example/src/AutoPlay.tsx
@@ -40,7 +40,7 @@ const AutoPlayRoot = (props: RootComponentInitialProps) => {
   const [signedIn, setSignedIn] = useState(Platform.OS !== 'android');
 
   useEffect(() => {
-    if (Platform.OS === 'android' && mapTemplate && !signedIn) {
+    if (Platform.OS === 'android' && mapTemplate.current && !signedIn) {
       const signInFinishedListener = () => {
         setTimeout(() => {
           // delay this a bit, so we show the alert when the map template is visible again, otherwise it will not be shown
@@ -49,7 +49,7 @@ const AutoPlayRoot = (props: RootComponentInitialProps) => {
       };
       AutoSignInTemplate.getTemplate(signInFinishedListener).push();
     }
-  }, [mapTemplate, signedIn]);
+  }, [mapTemplate.current, signedIn]);
 
   useEffect(() => {
     if (!signedIn) {
@@ -74,7 +74,7 @@ const AutoPlayRoot = (props: RootComponentInitialProps) => {
     const timer = setInterval(() => setI((p) => p + 1), 1000);
 
     return () => clearInterval(timer);
-  }, [signedIn, mapTemplate]);
+  }, [signedIn, mapTemplate.current]);
 
   useEffect(() => {
     const listeners: Array<UnsubscribeListener> = [];
@@ -155,7 +155,7 @@ const AutoPlayRoot = (props: RootComponentInitialProps) => {
     return () => {
       listeners.forEach((remove) => remove());
     };
-  }, [mapTemplate]);
+  }, [mapTemplate.current]);
 
   return (
     <SafeAreaView

--- a/packages/react-native-autoplay/src/components/MapTemplateContext.tsx
+++ b/packages/react-native-autoplay/src/components/MapTemplateContext.tsx
@@ -1,8 +1,12 @@
 import type React from 'react';
-import { createContext } from 'react';
-import type { MapTemplate } from '..';
+import { createContext, type RefObject, useEffect, useRef } from 'react';
+import { HybridAutoPlay, type MapTemplate } from '..';
 
-export const MapTemplateContext = createContext<MapTemplate | null>(null);
+export type MapTemplateRef = RefObject<MapTemplate | null>;
+
+const defaultRef: MapTemplateRef = { current: null };
+
+export const MapTemplateContext = createContext<MapTemplateRef>(defaultRef);
 
 export function MapTemplateProvider({
   children,
@@ -11,5 +15,19 @@ export function MapTemplateProvider({
   children: React.ReactNode;
   mapTemplate: MapTemplate;
 }) {
-  return <MapTemplateContext.Provider value={mapTemplate}>{children}</MapTemplateContext.Provider>;
+  const templateRef = useRef<MapTemplate | null>(mapTemplate);
+  templateRef.current = mapTemplate;
+
+  useEffect(() => {
+    // in react-native the children run their cleanup functions in the useEffects first, so we can't set it to null in the cleanup function of this
+    // component, but rather need to use the disconnect handler, which is called before all the components are unmounted. Like that an invalid
+    // map template can't be used anymore in the childrens cleanup functions, which prevents accessing native code, when the head unit disconnects.
+    const removeListener = HybridAutoPlay.addListener('didDisconnect', () => {
+      templateRef.current = null;
+    });
+
+    return removeListener;
+  }, []);
+
+  return <MapTemplateContext.Provider value={templateRef}>{children}</MapTemplateContext.Provider>;
 }

--- a/packages/react-native-autoplay/src/hooks/useMapTemplate.ts
+++ b/packages/react-native-autoplay/src/hooks/useMapTemplate.ts
@@ -1,10 +1,17 @@
 import { useContext } from 'react';
-import { MapTemplateContext } from '../components/MapTemplateContext';
+import { type MapTemplateRef, MapTemplateContext } from '../components/MapTemplateContext';
+
+export type { MapTemplateRef } from '../components/MapTemplateContext';
 
 /**
- * provides access to the map template
- * obviously this works only on the map template component and its children
+ * Provides access to the map template via a ref.
+ * The returned ref's `.current` is null when disconnected, preventing
+ * native calls after CarPlay/Android Auto disconnects.
+ *
+ * Always check `ref.current` for null before use.
+ * In useEffect cleanups, reading `ref.current` will correctly return null
+ * if a disconnect happened before the cleanup runs.
  */
-export const useMapTemplate = () => {
+export const useMapTemplate = (): MapTemplateRef => {
   return useContext(MapTemplateContext);
 };


### PR DESCRIPTION
**This is a breaking change.** We probably should make a version 0.4 if we want to do it like this.

The issue is, that on disconnect when we have a logic like
```
const mapTemplate = useMapTemplate()

useEffect(() => {
  mapTemplate.showTripSelector()
  return () => {
    mapTemplate.hideTripSelector()
  }
}, 
[mapTemplate, ...otherProps])
```
where we actually want to hide the trip selector based on other props, the mapTemplate would actually not be valid anymore in the cleanup function on unmount. However it is still defined, so calling that action we will run the native code, although it is already in the process of tearing down everything. Right now this would cause an exception, that the scene is not valid anymore.

When using a ref like in this PR we would be able, to immediately reset the state of the mapTemplate, even if the UI wouldn't render anymore. So the useEffect would look like this:
```
const mapTemplateRef = useMapTemplate()

useEffect(() => {
  mapTemplateRef.current?.showTripSelector()
  return () => {
    mapTemplate.current?.hideTripSelector()
  }
}, 
[mapTemplateRef.current, ...otherProps])
```
And the cleanup function wouldn't do anything, as the ref is already set to null when getting there.

This could potentially replace https://github.com/Iternio-Planning-AB/react-native-auto-play/pull/52 as we wouldn't have to check for the connection state on native side. We could however still keep the logic about not throwing when the scene is gone. Not sure though if we actually need it...