### PR TITLE
fix: id token not requested

### DIFF
--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/SignInWithGoogleActivity.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/SignInWithGoogleActivity.kt
@@ -34,7 +34,10 @@ class SignInWithGoogleActivity : ComponentActivity() {
         val googleSignInClient = GoogleSignIn.getClient(
             this,
             GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-                .requestServerAuthCode(serverClientId).requestEmail().build()
+                .requestServerAuthCode(serverClientId)
+                .requestEmail()
+                .requestIdToken(serverClientId)
+                .build()
         )
         activityResultLauncher.launch(googleSignInClient.signInIntent)
     }


### PR DESCRIPTION
This PR fixes an issue that the idToken was always null when doing a Google sign in.