### PR TITLE
fix: get screen manager from first non-cluster session

### DIFF
--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/AndroidAutoScreen.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/AndroidAutoScreen.kt
@@ -124,8 +124,11 @@ class AndroidAutoScreen(
         }
 
         fun getScreenManager(): ScreenManager? {
-            return screens[AndroidAutoSession.ROOT_SESSION]?.screenManager
-        }
+            val clusterSessions = AndroidAutoSession.getClusterSessions().toSet()
+            return screens.entries
+                .firstOrNull { !clusterSessions.contains(it.key) }
+                ?.value?.screenManager
+         }
 
         fun invalidateScreens() {
             for (screen in screens) {

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/AndroidAutoScreen.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/AndroidAutoScreen.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import com.facebook.react.bridge.UiThreadUtil
+import java.util.concurrent.ConcurrentHashMap
 import com.margelo.nitro.swe.iternio.reactnativeautoplay.template.AndroidAutoTemplate
 import com.margelo.nitro.swe.iternio.reactnativeautoplay.template.GridTemplate
 import com.margelo.nitro.swe.iternio.reactnativeautoplay.template.InformationTemplate
@@ -117,7 +118,7 @@ class AndroidAutoScreen(
     companion object {
         const val TAG = "AndroidAutoScreen"
 
-        private val screens = mutableMapOf<String, AndroidAutoScreen>()
+        private val screens = ConcurrentHashMap<String, AndroidAutoScreen>()
 
         fun getScreen(marker: String): AndroidAutoScreen? {
             return screens[marker]

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/AndroidAutoSession.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/AndroidAutoSession.kt
@@ -23,6 +23,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
 
 class AndroidAutoSession(sessionInfo: SessionInfo, private val reactApplication: ReactApplication) :
     Session() {
@@ -246,9 +248,9 @@ class AndroidAutoSession(sessionInfo: SessionInfo, private val reactApplication:
         const val ROOT_SESSION = "AutoPlayRoot"
 
         private lateinit var reactContext: ReactContext
-        private val sessions = mutableMapOf<String, ScreenContext>()
+        private val sessions = ConcurrentHashMap<String, ScreenContext>()
 
-        private val clusterSessions = mutableListOf<String>()
+        private val clusterSessions = CopyOnWriteArrayList<String>()
 
         fun getIsConnected(): Boolean {
             return sessions.containsKey(ROOT_SESSION)


### PR DESCRIPTION
This is a fix for the error which I encountered when set `GridTemplate` as a root template on Android Auto
Here is a repository with minimal app which reproduces the error: [link](https://github.com/laptiieff/android-auto-error-app). Steps to reproduce and fix the error (via patch) are described in readme, as well as short screen recordings of before and after fix behaviors