### PR TITLE
fix: defer makeKeyAndVisible to suppress UIKit rendering warning

### DIFF
--- a/packages/react-native-autoplay/ios/scenes/WindowApplicationSceneDelegate.swift
+++ b/packages/react-native-autoplay/ios/scenes/WindowApplicationSceneDelegate.swift
@@ -27,9 +27,14 @@ class WindowApplicationSceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         let window = UIWindow(windowScene: windowScene)
         window.rootViewController = rootViewController
-        window.makeKeyAndVisible()
-
         self.window = window
+
+        // Defer makeKeyAndVisible to the next run loop iteration so UIKit can
+        // lay out the transplanted view hierarchy in the new scene-based window
+        // before the first render pass.
+        DispatchQueue.main.async {
+            window.makeKeyAndVisible()
+        }
 
         if let url = connectionOptions.urlContexts.first?.url {
             // Linking API -> on app start


### PR DESCRIPTION
`WindowApplicationSceneDelegate` transplants the root view controller from the AppDelegate's non-scene window into a new scene-based `UIWindow` and immediately calls `makeKeyAndVisible()`. This triggers a repeated UIKit console warning:

```
[UIKitCore] Rendering a view (0x…, UIWindow) that has not been rendered
at least once requires afterScreenUpdates:YES.
```

The fix defers `makeKeyAndVisible()` to the next run loop iteration via `DispatchQueue.main.async`, giving UIKit time to lay out the transplanted view hierarchy before the first render pass.

Tested with Expo SDK 55 / React Native 0.83 on the Xcode Simulator CarPlay window — warning is eliminated with no change in behavior.