### PR TITLE
Loading maneuver background color

### DIFF
--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/AndroidAutoSession.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/AndroidAutoSession.kt
@@ -55,6 +55,7 @@ class AndroidAutoSession(sessionInfo: SessionInfo) :
                 null,
                 arrayOf(action),
                 null,
+                null,
                 null
             )
 

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/MapTemplate.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/template/MapTemplate.kt
@@ -66,6 +66,10 @@ class MapTemplate(
                 navigationManager.setNavigationManagerCallback(navigationManagerCallback)
             }
         }
+
+        config.defaultGuidanceBackgroundColor?.let { nitroColor ->
+            MapTemplate.cardBackgroundColor = Parser.parseColor(nitroColor)
+        }
     }
 
     override fun parse(): Template {
@@ -329,7 +333,9 @@ class MapTemplate(
             }
 
             if (loadingInfo != null) {
+                cardBackgroundColor = Parser.parseColor(loadingInfo.cardBackgroundColor)
                 navigationInfo = RoutingInfo.Builder().setLoading(true).build()
+                AndroidAutoScreen.invalidateSurfaceScreens()
                 return
             }
 

--- a/packages/react-native-autoplay/ios/hybrid/HybridMapTemplate.swift
+++ b/packages/react-native-autoplay/ios/hybrid/HybridMapTemplate.swift
@@ -138,12 +138,9 @@ class HybridMapTemplate: HybridMapTemplateSpec {
                 {
                     template.updateManeuvers(messageManeuver: messageManeuver)
                 }()
-            case .third(let loadingManeuver):
+            case .third(let loading):
                 {
-                    template.navigationSession?.pauseTrip(
-                        for: .loading,
-                        description: nil
-                    )
+                    template.updateManeuversLoading(loading: loading)
                 }()
             }
 

--- a/packages/react-native-autoplay/ios/templates/MapTemplate.swift
+++ b/packages/react-native-autoplay/ios/templates/MapTemplate.swift
@@ -50,6 +50,18 @@ class MapTemplate: AutoPlayHeaderProviding,
         visibleTravelEstimate = config.visibleTravelEstimate
 
         template = CPMapTemplate(id: config.id)
+        if let nitroColor = config.defaultGuidanceBackgroundColor,
+            let traitCollection = SceneStore.getRootTraitCollection()
+        {
+            let cardBackgroundColor = Parser.routingManeuverCardBackgroundUIColor(
+                color: nitroColor,
+                traitCollection: traitCollection
+            )
+            template.guidanceBackgroundColor = cardBackgroundColor
+        }
+        else {
+            template.guidanceBackgroundColor = .black
+        }
 
         if let initialProperties = SceneStore.getRootScene()?.initialProperties,
             let windowDict = initialProperties["window"] as? [String: Any],
@@ -605,6 +617,35 @@ class MapTemplate: AutoPlayHeaderProviding,
         }
 
         updateVisibleTravelEstimate(visibleTravelEstimate: nil)
+    }
+
+    func updateManeuversLoading(loading: NitroLoadingManeuver) {
+        guard let navigationSession = navigationSession else { return }
+
+        let description = loading.text
+
+        guard let traitCollection = SceneStore.getRootTraitCollection() else {
+            navigationSession.pauseTrip(for: .loading, description: description)
+            return
+        }
+
+        let cardBackgroundColor = Parser.routingManeuverCardBackgroundUIColor(
+            color: loading.cardBackgroundColor,
+            traitCollection: traitCollection
+        )
+
+        template.guidanceBackgroundColor = cardBackgroundColor
+
+        if #available(iOS 18.0, *) {
+            navigationSession.pauseTrip(
+                for: .loading,
+                description: description,
+                turnCardColor: cardBackgroundColor
+            )
+        }
+        else {
+            navigationSession.pauseTrip(for: .loading, description: description)
+        }
     }
 
     func updateManeuvers(messageManeuver: NitroMessageManeuver) {

--- a/packages/react-native-autoplay/ios/templates/Parser.swift
+++ b/packages/react-native-autoplay/ios/templates/Parser.swift
@@ -503,6 +503,21 @@ class Parser {
         )
     }
 
+    /// Card background `UIColor` for routing maneuvers and loading pause — same light/dark component pick as `parseManeuver`.
+    static func routingManeuverCardBackgroundUIColor(
+        color: NitroColor,
+        traitCollection: UITraitCollection
+    ) -> UIColor {
+        if #available(iOS 15.4, *) {
+            let component =
+                traitCollection.userInterfaceStyle == .dark
+                ? color.darkColor
+                : color.lightColor
+            return doubleToColor(value: component)
+        }
+        return parseColor(color: color)
+    }
+
     static func parseManeuver(
         nitroManeuver: NitroRoutingManeuver,
         traitCollection: UITraitCollection
@@ -528,13 +543,9 @@ class Parser {
         )
 
         if #available(iOS 15.4, *) {
-            let cardBackgroundColor =
-                traitCollection.userInterfaceStyle == .dark
-                ? nitroManeuver.cardBackgroundColor.darkColor
-                : nitroManeuver.cardBackgroundColor.lightColor
-
-            maneuver.cardBackgroundColor = doubleToColor(
-                value: cardBackgroundColor
+            maneuver.cardBackgroundColor = routingManeuverCardBackgroundUIColor(
+                color: nitroManeuver.cardBackgroundColor,
+                traitCollection: traitCollection
             )
         }
 

--- a/packages/react-native-autoplay/nitrogen/generated/android/c++/JMapTemplateConfig.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/android/c++/JMapTemplateConfig.hpp
@@ -103,6 +103,8 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
       jni::local_ref<jni::JArrayClass<JNitroMapButton>> mapButtons = this->getFieldValue(fieldMapButtons);
       static const auto fieldHeaderActions = clazz->getField<jni::JArrayClass<JNitroAction>>("headerActions");
       jni::local_ref<jni::JArrayClass<JNitroAction>> headerActions = this->getFieldValue(fieldHeaderActions);
+      static const auto fieldDefaultGuidanceBackgroundColor = clazz->getField<JNitroColor>("defaultGuidanceBackgroundColor");
+      jni::local_ref<JNitroColor> defaultGuidanceBackgroundColor = this->getFieldValue(fieldDefaultGuidanceBackgroundColor);
       static const auto fieldPanButtonScrollPercentage = clazz->getField<jni::JDouble>("panButtonScrollPercentage");
       jni::local_ref<jni::JDouble> panButtonScrollPercentage = this->getFieldValue(fieldPanButtonScrollPercentage);
       static const auto fieldOnDidChangePanningInterface = clazz->getField<JFunc_void_bool::javaobject>("onDidChangePanningInterface");
@@ -239,6 +241,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
           }
           return __vector;
         }()) : std::nullopt,
+        defaultGuidanceBackgroundColor != nullptr ? std::make_optional(defaultGuidanceBackgroundColor->toCpp()) : std::nullopt,
         panButtonScrollPercentage != nullptr ? std::make_optional(panButtonScrollPercentage->value()) : std::nullopt,
         onDidChangePanningInterface != nullptr ? std::make_optional([&]() -> std::function<void(bool /* isPanningInterfaceVisible */)> {
           if (onDidChangePanningInterface->isInstanceOf(JFunc_void_bool_cxx::javaClassStatic())) [[likely]] {
@@ -258,7 +261,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
      */
     [[maybe_unused]]
     static jni::local_ref<JMapTemplateConfig::javaobject> fromCpp(const MapTemplateConfig& value) {
-      using JSignature = JMapTemplateConfig(jni::alias_ref<jni::JString>, jni::alias_ref<JFunc_void_std__optional_bool_::javaobject>, jni::alias_ref<JFunc_void_std__optional_bool_::javaobject>, jni::alias_ref<JFunc_void_std__optional_bool_::javaobject>, jni::alias_ref<JFunc_void_std__optional_bool_::javaobject>, jni::alias_ref<JFunc_void::javaobject>, jni::alias_ref<jni::JDouble>, jni::alias_ref<JVisibleTravelEstimate>, jni::alias_ref<JFunc_void_Point_std__optional_Point_::javaobject>, jni::alias_ref<JFunc_void_Point_double::javaobject>, jni::alias_ref<JFunc_void_Point::javaobject>, jni::alias_ref<JFunc_void_Point::javaobject>, jni::alias_ref<JFunc_void_ColorScheme::javaobject>, jni::alias_ref<JFunc_void::javaobject>, jni::alias_ref<JFunc_void::javaobject>, jni::alias_ref<jni::JArrayClass<JNitroMapButton>>, jni::alias_ref<jni::JArrayClass<JNitroAction>>, jni::alias_ref<jni::JDouble>, jni::alias_ref<JFunc_void_bool::javaobject>);
+      using JSignature = JMapTemplateConfig(jni::alias_ref<jni::JString>, jni::alias_ref<JFunc_void_std__optional_bool_::javaobject>, jni::alias_ref<JFunc_void_std__optional_bool_::javaobject>, jni::alias_ref<JFunc_void_std__optional_bool_::javaobject>, jni::alias_ref<JFunc_void_std__optional_bool_::javaobject>, jni::alias_ref<JFunc_void::javaobject>, jni::alias_ref<jni::JDouble>, jni::alias_ref<JVisibleTravelEstimate>, jni::alias_ref<JFunc_void_Point_std__optional_Point_::javaobject>, jni::alias_ref<JFunc_void_Point_double::javaobject>, jni::alias_ref<JFunc_void_Point::javaobject>, jni::alias_ref<JFunc_void_Point::javaobject>, jni::alias_ref<JFunc_void_ColorScheme::javaobject>, jni::alias_ref<JFunc_void::javaobject>, jni::alias_ref<JFunc_void::javaobject>, jni::alias_ref<jni::JArrayClass<JNitroMapButton>>, jni::alias_ref<jni::JArrayClass<JNitroAction>>, jni::alias_ref<JNitroColor>, jni::alias_ref<jni::JDouble>, jni::alias_ref<JFunc_void_bool::javaobject>);
       static const auto clazz = javaClassStatic();
       static const auto create = clazz->getStaticMethod<JSignature>("fromCpp");
       return create(
@@ -298,6 +301,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
           }
           return __array;
         }() : nullptr,
+        value.defaultGuidanceBackgroundColor.has_value() ? JNitroColor::fromCpp(value.defaultGuidanceBackgroundColor.value()) : nullptr,
         value.panButtonScrollPercentage.has_value() ? jni::JDouble::valueOf(value.panButtonScrollPercentage.value()) : nullptr,
         value.onDidChangePanningInterface.has_value() ? JFunc_void_bool_cxx::fromCpp(value.onDidChangePanningInterface.value()) : nullptr
       );

--- a/packages/react-native-autoplay/nitrogen/generated/android/c++/JNitroLoadingManeuver.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/android/c++/JNitroLoadingManeuver.hpp
@@ -10,7 +10,10 @@
 #include <fbjni/fbjni.h>
 #include "NitroLoadingManeuver.hpp"
 
-
+#include "JNitroColor.hpp"
+#include "NitroColor.hpp"
+#include <optional>
+#include <string>
 
 namespace margelo::nitro::swe::iternio::reactnativeautoplay {
 
@@ -33,8 +36,14 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
       static const auto clazz = javaClassStatic();
       static const auto fieldIsLoading = clazz->getField<jboolean>("isLoading");
       jboolean isLoading = this->getFieldValue(fieldIsLoading);
+      static const auto fieldCardBackgroundColor = clazz->getField<JNitroColor>("cardBackgroundColor");
+      jni::local_ref<JNitroColor> cardBackgroundColor = this->getFieldValue(fieldCardBackgroundColor);
+      static const auto fieldText = clazz->getField<jni::JString>("text");
+      jni::local_ref<jni::JString> text = this->getFieldValue(fieldText);
       return NitroLoadingManeuver(
-        static_cast<bool>(isLoading)
+        static_cast<bool>(isLoading),
+        cardBackgroundColor->toCpp(),
+        text != nullptr ? std::make_optional(text->toStdString()) : std::nullopt
       );
     }
 
@@ -44,12 +53,14 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
      */
     [[maybe_unused]]
     static jni::local_ref<JNitroLoadingManeuver::javaobject> fromCpp(const NitroLoadingManeuver& value) {
-      using JSignature = JNitroLoadingManeuver(jboolean);
+      using JSignature = JNitroLoadingManeuver(jboolean, jni::alias_ref<JNitroColor>, jni::alias_ref<jni::JString>);
       static const auto clazz = javaClassStatic();
       static const auto create = clazz->getStaticMethod<JSignature>("fromCpp");
       return create(
         clazz,
-        value.isLoading
+        value.isLoading,
+        JNitroColor::fromCpp(value.cardBackgroundColor),
+        value.text.has_value() ? jni::make_jstring(value.text.value()) : nullptr
       );
     }
   };

--- a/packages/react-native-autoplay/nitrogen/generated/android/kotlin/com/margelo/nitro/swe/iternio/reactnativeautoplay/MapTemplateConfig.kt
+++ b/packages/react-native-autoplay/nitrogen/generated/android/kotlin/com/margelo/nitro/swe/iternio/reactnativeautoplay/MapTemplateConfig.kt
@@ -70,6 +70,9 @@ data class MapTemplateConfig(
   val headerActions: Array<NitroAction>?,
   @DoNotStrip
   @Keep
+  val defaultGuidanceBackgroundColor: NitroColor?,
+  @DoNotStrip
+  @Keep
   val panButtonScrollPercentage: Double?,
   @DoNotStrip
   @Keep
@@ -78,8 +81,8 @@ data class MapTemplateConfig(
   /**
    * Create a new instance of MapTemplateConfig from Kotlin
    */
-  constructor(id: String, onWillAppear: ((animated: Boolean?) -> Unit)?, onWillDisappear: ((animated: Boolean?) -> Unit)?, onDidAppear: ((animated: Boolean?) -> Unit)?, onDidDisappear: ((animated: Boolean?) -> Unit)?, onPopped: (() -> Unit)?, autoDismissMs: Double?, visibleTravelEstimate: VisibleTravelEstimate?, onDidPan: ((translation: Point, velocity: Point?) -> Unit)?, onDidUpdateZoomGestureWithCenter: ((center: Point, scale: Double) -> Unit)?, onClick: ((center: Point) -> Unit)?, onDoubleClick: ((center: Point) -> Unit)?, onAppearanceDidChange: ((colorScheme: ColorScheme) -> Unit)?, onStopNavigation: () -> Unit, onAutoDriveEnabled: (() -> Unit)?, mapButtons: Array<NitroMapButton>?, headerActions: Array<NitroAction>?, panButtonScrollPercentage: Double?, onDidChangePanningInterface: ((isPanningInterfaceVisible: Boolean) -> Unit)?):
-         this(id, onWillAppear?.let { Func_void_std__optional_bool__java(it) }, onWillDisappear?.let { Func_void_std__optional_bool__java(it) }, onDidAppear?.let { Func_void_std__optional_bool__java(it) }, onDidDisappear?.let { Func_void_std__optional_bool__java(it) }, onPopped?.let { Func_void_java(it) }, autoDismissMs, visibleTravelEstimate, onDidPan?.let { Func_void_Point_std__optional_Point__java(it) }, onDidUpdateZoomGestureWithCenter?.let { Func_void_Point_double_java(it) }, onClick?.let { Func_void_Point_java(it) }, onDoubleClick?.let { Func_void_Point_java(it) }, onAppearanceDidChange?.let { Func_void_ColorScheme_java(it) }, Func_void_java(onStopNavigation), onAutoDriveEnabled?.let { Func_void_java(it) }, mapButtons, headerActions, panButtonScrollPercentage, onDidChangePanningInterface?.let { Func_void_bool_java(it) })
+  constructor(id: String, onWillAppear: ((animated: Boolean?) -> Unit)?, onWillDisappear: ((animated: Boolean?) -> Unit)?, onDidAppear: ((animated: Boolean?) -> Unit)?, onDidDisappear: ((animated: Boolean?) -> Unit)?, onPopped: (() -> Unit)?, autoDismissMs: Double?, visibleTravelEstimate: VisibleTravelEstimate?, onDidPan: ((translation: Point, velocity: Point?) -> Unit)?, onDidUpdateZoomGestureWithCenter: ((center: Point, scale: Double) -> Unit)?, onClick: ((center: Point) -> Unit)?, onDoubleClick: ((center: Point) -> Unit)?, onAppearanceDidChange: ((colorScheme: ColorScheme) -> Unit)?, onStopNavigation: () -> Unit, onAutoDriveEnabled: (() -> Unit)?, mapButtons: Array<NitroMapButton>?, headerActions: Array<NitroAction>?, defaultGuidanceBackgroundColor: NitroColor?, panButtonScrollPercentage: Double?, onDidChangePanningInterface: ((isPanningInterfaceVisible: Boolean) -> Unit)?):
+         this(id, onWillAppear?.let { Func_void_std__optional_bool__java(it) }, onWillDisappear?.let { Func_void_std__optional_bool__java(it) }, onDidAppear?.let { Func_void_std__optional_bool__java(it) }, onDidDisappear?.let { Func_void_std__optional_bool__java(it) }, onPopped?.let { Func_void_java(it) }, autoDismissMs, visibleTravelEstimate, onDidPan?.let { Func_void_Point_std__optional_Point__java(it) }, onDidUpdateZoomGestureWithCenter?.let { Func_void_Point_double_java(it) }, onClick?.let { Func_void_Point_java(it) }, onDoubleClick?.let { Func_void_Point_java(it) }, onAppearanceDidChange?.let { Func_void_ColorScheme_java(it) }, Func_void_java(onStopNavigation), onAutoDriveEnabled?.let { Func_void_java(it) }, mapButtons, headerActions, defaultGuidanceBackgroundColor, panButtonScrollPercentage, onDidChangePanningInterface?.let { Func_void_bool_java(it) })
 
   companion object {
     /**
@@ -89,8 +92,8 @@ data class MapTemplateConfig(
     @Keep
     @Suppress("unused")
     @JvmStatic
-    private fun fromCpp(id: String, onWillAppear: Func_void_std__optional_bool_?, onWillDisappear: Func_void_std__optional_bool_?, onDidAppear: Func_void_std__optional_bool_?, onDidDisappear: Func_void_std__optional_bool_?, onPopped: Func_void?, autoDismissMs: Double?, visibleTravelEstimate: VisibleTravelEstimate?, onDidPan: Func_void_Point_std__optional_Point_?, onDidUpdateZoomGestureWithCenter: Func_void_Point_double?, onClick: Func_void_Point?, onDoubleClick: Func_void_Point?, onAppearanceDidChange: Func_void_ColorScheme?, onStopNavigation: Func_void, onAutoDriveEnabled: Func_void?, mapButtons: Array<NitroMapButton>?, headerActions: Array<NitroAction>?, panButtonScrollPercentage: Double?, onDidChangePanningInterface: Func_void_bool?): MapTemplateConfig {
-      return MapTemplateConfig(id, onWillAppear, onWillDisappear, onDidAppear, onDidDisappear, onPopped, autoDismissMs, visibleTravelEstimate, onDidPan, onDidUpdateZoomGestureWithCenter, onClick, onDoubleClick, onAppearanceDidChange, onStopNavigation, onAutoDriveEnabled, mapButtons, headerActions, panButtonScrollPercentage, onDidChangePanningInterface)
+    private fun fromCpp(id: String, onWillAppear: Func_void_std__optional_bool_?, onWillDisappear: Func_void_std__optional_bool_?, onDidAppear: Func_void_std__optional_bool_?, onDidDisappear: Func_void_std__optional_bool_?, onPopped: Func_void?, autoDismissMs: Double?, visibleTravelEstimate: VisibleTravelEstimate?, onDidPan: Func_void_Point_std__optional_Point_?, onDidUpdateZoomGestureWithCenter: Func_void_Point_double?, onClick: Func_void_Point?, onDoubleClick: Func_void_Point?, onAppearanceDidChange: Func_void_ColorScheme?, onStopNavigation: Func_void, onAutoDriveEnabled: Func_void?, mapButtons: Array<NitroMapButton>?, headerActions: Array<NitroAction>?, defaultGuidanceBackgroundColor: NitroColor?, panButtonScrollPercentage: Double?, onDidChangePanningInterface: Func_void_bool?): MapTemplateConfig {
+      return MapTemplateConfig(id, onWillAppear, onWillDisappear, onDidAppear, onDidDisappear, onPopped, autoDismissMs, visibleTravelEstimate, onDidPan, onDidUpdateZoomGestureWithCenter, onClick, onDoubleClick, onAppearanceDidChange, onStopNavigation, onAutoDriveEnabled, mapButtons, headerActions, defaultGuidanceBackgroundColor, panButtonScrollPercentage, onDidChangePanningInterface)
     }
   }
 }

--- a/packages/react-native-autoplay/nitrogen/generated/android/kotlin/com/margelo/nitro/swe/iternio/reactnativeautoplay/NitroLoadingManeuver.kt
+++ b/packages/react-native-autoplay/nitrogen/generated/android/kotlin/com/margelo/nitro/swe/iternio/reactnativeautoplay/NitroLoadingManeuver.kt
@@ -19,7 +19,13 @@ import com.facebook.proguard.annotations.DoNotStrip
 data class NitroLoadingManeuver(
   @DoNotStrip
   @Keep
-  val isLoading: Boolean
+  val isLoading: Boolean,
+  @DoNotStrip
+  @Keep
+  val cardBackgroundColor: NitroColor,
+  @DoNotStrip
+  @Keep
+  val text: String?
 ) {
   /* primary constructor */
 
@@ -31,8 +37,8 @@ data class NitroLoadingManeuver(
     @Keep
     @Suppress("unused")
     @JvmStatic
-    private fun fromCpp(isLoading: Boolean): NitroLoadingManeuver {
-      return NitroLoadingManeuver(isLoading)
+    private fun fromCpp(isLoading: Boolean, cardBackgroundColor: NitroColor, text: String?): NitroLoadingManeuver {
+      return NitroLoadingManeuver(isLoading, cardBackgroundColor, text)
     }
   }
 }

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/MapTemplateConfig.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/MapTemplateConfig.swift
@@ -18,7 +18,7 @@ public extension MapTemplateConfig {
   /**
    * Create a new instance of `MapTemplateConfig`.
    */
-  init(id: String, onWillAppear: ((_ animated: Bool?) -> Void)?, onWillDisappear: ((_ animated: Bool?) -> Void)?, onDidAppear: ((_ animated: Bool?) -> Void)?, onDidDisappear: ((_ animated: Bool?) -> Void)?, onPopped: (() -> Void)?, autoDismissMs: Double?, visibleTravelEstimate: VisibleTravelEstimate?, onDidPan: ((_ translation: Point, _ velocity: Point?) -> Void)?, onDidUpdateZoomGestureWithCenter: ((_ center: Point, _ scale: Double) -> Void)?, onClick: ((_ center: Point) -> Void)?, onDoubleClick: ((_ center: Point) -> Void)?, onAppearanceDidChange: ((_ colorScheme: ColorScheme) -> Void)?, onStopNavigation: @escaping () -> Void, onAutoDriveEnabled: (() -> Void)?, mapButtons: [NitroMapButton]?, headerActions: [NitroAction]?, panButtonScrollPercentage: Double?, onDidChangePanningInterface: ((_ isPanningInterfaceVisible: Bool) -> Void)?) {
+  init(id: String, onWillAppear: ((_ animated: Bool?) -> Void)?, onWillDisappear: ((_ animated: Bool?) -> Void)?, onDidAppear: ((_ animated: Bool?) -> Void)?, onDidDisappear: ((_ animated: Bool?) -> Void)?, onPopped: (() -> Void)?, autoDismissMs: Double?, visibleTravelEstimate: VisibleTravelEstimate?, onDidPan: ((_ translation: Point, _ velocity: Point?) -> Void)?, onDidUpdateZoomGestureWithCenter: ((_ center: Point, _ scale: Double) -> Void)?, onClick: ((_ center: Point) -> Void)?, onDoubleClick: ((_ center: Point) -> Void)?, onAppearanceDidChange: ((_ colorScheme: ColorScheme) -> Void)?, onStopNavigation: @escaping () -> Void, onAutoDriveEnabled: (() -> Void)?, mapButtons: [NitroMapButton]?, headerActions: [NitroAction]?, defaultGuidanceBackgroundColor: NitroColor?, panButtonScrollPercentage: Double?, onDidChangePanningInterface: ((_ isPanningInterfaceVisible: Bool) -> Void)?) {
     self.init(std.string(id), { () -> bridge.std__optional_std__function_void_std__optional_bool_____animated______ in
       if let __unwrappedValue = onWillAppear {
         return bridge.create_std__optional_std__function_void_std__optional_bool_____animated______({ () -> bridge.Func_void_std__optional_bool_ in
@@ -154,6 +154,12 @@ public extension MapTemplateConfig {
           }
           return __vector
         }())
+      } else {
+        return .init()
+      }
+    }(), { () -> bridge.std__optional_NitroColor_ in
+      if let __unwrappedValue = defaultGuidanceBackgroundColor {
+        return bridge.create_std__optional_NitroColor_(__unwrappedValue)
       } else {
         return .init()
       }
@@ -446,6 +452,11 @@ public extension MapTemplateConfig {
         return nil
       }
     }()
+  }
+  
+  @inline(__always)
+  var defaultGuidanceBackgroundColor: NitroColor? {
+    return self.__defaultGuidanceBackgroundColor.value
   }
   
   @inline(__always)

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroLoadingManeuver.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/NitroLoadingManeuver.swift
@@ -18,12 +18,35 @@ public extension NitroLoadingManeuver {
   /**
    * Create a new instance of `NitroLoadingManeuver`.
    */
-  init(isLoading: Bool) {
-    self.init(isLoading)
+  init(isLoading: Bool, cardBackgroundColor: NitroColor, text: String?) {
+    self.init(isLoading, cardBackgroundColor, { () -> bridge.std__optional_std__string_ in
+      if let __unwrappedValue = text {
+        return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
+      } else {
+        return .init()
+      }
+    }())
   }
 
   @inline(__always)
   var isLoading: Bool {
     return self.__isLoading
+  }
+  
+  @inline(__always)
+  var cardBackgroundColor: NitroColor {
+    return self.__cardBackgroundColor
+  }
+  
+  @inline(__always)
+  var text: String? {
+    return { () -> String? in
+      if bridge.has_value_std__optional_std__string_(self.__text) {
+        let __unwrapped = bridge.get_std__optional_std__string_(self.__text)
+        return String(__unwrapped)
+      } else {
+        return nil
+      }
+    }()
   }
 }

--- a/packages/react-native-autoplay/nitrogen/generated/shared/c++/MapTemplateConfig.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/shared/c++/MapTemplateConfig.hpp
@@ -38,6 +38,8 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay { enum class ColorSc
 namespace margelo::nitro::swe::iternio::reactnativeautoplay { struct NitroMapButton; }
 // Forward declaration of `NitroAction` to properly resolve imports.
 namespace margelo::nitro::swe::iternio::reactnativeautoplay { struct NitroAction; }
+// Forward declaration of `NitroColor` to properly resolve imports.
+namespace margelo::nitro::swe::iternio::reactnativeautoplay { struct NitroColor; }
 
 #include <string>
 #include <optional>
@@ -48,6 +50,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay { struct NitroAction
 #include "NitroMapButton.hpp"
 #include <vector>
 #include "NitroAction.hpp"
+#include "NitroColor.hpp"
 
 namespace margelo::nitro::swe::iternio::reactnativeautoplay {
 
@@ -73,12 +76,13 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
     std::optional<std::function<void()>> onAutoDriveEnabled     SWIFT_PRIVATE;
     std::optional<std::vector<NitroMapButton>> mapButtons     SWIFT_PRIVATE;
     std::optional<std::vector<NitroAction>> headerActions     SWIFT_PRIVATE;
+    std::optional<NitroColor> defaultGuidanceBackgroundColor     SWIFT_PRIVATE;
     std::optional<double> panButtonScrollPercentage     SWIFT_PRIVATE;
     std::optional<std::function<void(bool /* isPanningInterfaceVisible */)>> onDidChangePanningInterface     SWIFT_PRIVATE;
 
   public:
     MapTemplateConfig() = default;
-    explicit MapTemplateConfig(std::string id, std::optional<std::function<void(std::optional<bool> /* animated */)>> onWillAppear, std::optional<std::function<void(std::optional<bool> /* animated */)>> onWillDisappear, std::optional<std::function<void(std::optional<bool> /* animated */)>> onDidAppear, std::optional<std::function<void(std::optional<bool> /* animated */)>> onDidDisappear, std::optional<std::function<void()>> onPopped, std::optional<double> autoDismissMs, std::optional<VisibleTravelEstimate> visibleTravelEstimate, std::optional<std::function<void(const Point& /* translation */, const std::optional<Point>& /* velocity */)>> onDidPan, std::optional<std::function<void(const Point& /* center */, double /* scale */)>> onDidUpdateZoomGestureWithCenter, std::optional<std::function<void(const Point& /* center */)>> onClick, std::optional<std::function<void(const Point& /* center */)>> onDoubleClick, std::optional<std::function<void(ColorScheme /* colorScheme */)>> onAppearanceDidChange, std::function<void()> onStopNavigation, std::optional<std::function<void()>> onAutoDriveEnabled, std::optional<std::vector<NitroMapButton>> mapButtons, std::optional<std::vector<NitroAction>> headerActions, std::optional<double> panButtonScrollPercentage, std::optional<std::function<void(bool /* isPanningInterfaceVisible */)>> onDidChangePanningInterface): id(id), onWillAppear(onWillAppear), onWillDisappear(onWillDisappear), onDidAppear(onDidAppear), onDidDisappear(onDidDisappear), onPopped(onPopped), autoDismissMs(autoDismissMs), visibleTravelEstimate(visibleTravelEstimate), onDidPan(onDidPan), onDidUpdateZoomGestureWithCenter(onDidUpdateZoomGestureWithCenter), onClick(onClick), onDoubleClick(onDoubleClick), onAppearanceDidChange(onAppearanceDidChange), onStopNavigation(onStopNavigation), onAutoDriveEnabled(onAutoDriveEnabled), mapButtons(mapButtons), headerActions(headerActions), panButtonScrollPercentage(panButtonScrollPercentage), onDidChangePanningInterface(onDidChangePanningInterface) {}
+    explicit MapTemplateConfig(std::string id, std::optional<std::function<void(std::optional<bool> /* animated */)>> onWillAppear, std::optional<std::function<void(std::optional<bool> /* animated */)>> onWillDisappear, std::optional<std::function<void(std::optional<bool> /* animated */)>> onDidAppear, std::optional<std::function<void(std::optional<bool> /* animated */)>> onDidDisappear, std::optional<std::function<void()>> onPopped, std::optional<double> autoDismissMs, std::optional<VisibleTravelEstimate> visibleTravelEstimate, std::optional<std::function<void(const Point& /* translation */, const std::optional<Point>& /* velocity */)>> onDidPan, std::optional<std::function<void(const Point& /* center */, double /* scale */)>> onDidUpdateZoomGestureWithCenter, std::optional<std::function<void(const Point& /* center */)>> onClick, std::optional<std::function<void(const Point& /* center */)>> onDoubleClick, std::optional<std::function<void(ColorScheme /* colorScheme */)>> onAppearanceDidChange, std::function<void()> onStopNavigation, std::optional<std::function<void()>> onAutoDriveEnabled, std::optional<std::vector<NitroMapButton>> mapButtons, std::optional<std::vector<NitroAction>> headerActions, std::optional<NitroColor> defaultGuidanceBackgroundColor, std::optional<double> panButtonScrollPercentage, std::optional<std::function<void(bool /* isPanningInterfaceVisible */)>> onDidChangePanningInterface): id(id), onWillAppear(onWillAppear), onWillDisappear(onWillDisappear), onDidAppear(onDidAppear), onDidDisappear(onDidDisappear), onPopped(onPopped), autoDismissMs(autoDismissMs), visibleTravelEstimate(visibleTravelEstimate), onDidPan(onDidPan), onDidUpdateZoomGestureWithCenter(onDidUpdateZoomGestureWithCenter), onClick(onClick), onDoubleClick(onDoubleClick), onAppearanceDidChange(onAppearanceDidChange), onStopNavigation(onStopNavigation), onAutoDriveEnabled(onAutoDriveEnabled), mapButtons(mapButtons), headerActions(headerActions), defaultGuidanceBackgroundColor(defaultGuidanceBackgroundColor), panButtonScrollPercentage(panButtonScrollPercentage), onDidChangePanningInterface(onDidChangePanningInterface) {}
 
   public:
     // MapTemplateConfig is not equatable because these properties are not equatable: onWillAppear, onWillDisappear, onDidAppear, onDidDisappear, onPopped, onDidPan, onDidUpdateZoomGestureWithCenter, onClick, onDoubleClick, onAppearanceDidChange, onStopNavigation, onAutoDriveEnabled, mapButtons, headerActions, onDidChangePanningInterface
@@ -111,6 +115,7 @@ namespace margelo::nitro {
         JSIConverter<std::optional<std::function<void()>>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "onAutoDriveEnabled"))),
         JSIConverter<std::optional<std::vector<margelo::nitro::swe::iternio::reactnativeautoplay::NitroMapButton>>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "mapButtons"))),
         JSIConverter<std::optional<std::vector<margelo::nitro::swe::iternio::reactnativeautoplay::NitroAction>>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "headerActions"))),
+        JSIConverter<std::optional<margelo::nitro::swe::iternio::reactnativeautoplay::NitroColor>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "defaultGuidanceBackgroundColor"))),
         JSIConverter<std::optional<double>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "panButtonScrollPercentage"))),
         JSIConverter<std::optional<std::function<void(bool)>>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "onDidChangePanningInterface")))
       );
@@ -134,6 +139,7 @@ namespace margelo::nitro {
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "onAutoDriveEnabled"), JSIConverter<std::optional<std::function<void()>>>::toJSI(runtime, arg.onAutoDriveEnabled));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "mapButtons"), JSIConverter<std::optional<std::vector<margelo::nitro::swe::iternio::reactnativeautoplay::NitroMapButton>>>::toJSI(runtime, arg.mapButtons));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "headerActions"), JSIConverter<std::optional<std::vector<margelo::nitro::swe::iternio::reactnativeautoplay::NitroAction>>>::toJSI(runtime, arg.headerActions));
+      obj.setProperty(runtime, PropNameIDCache::get(runtime, "defaultGuidanceBackgroundColor"), JSIConverter<std::optional<margelo::nitro::swe::iternio::reactnativeautoplay::NitroColor>>::toJSI(runtime, arg.defaultGuidanceBackgroundColor));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "panButtonScrollPercentage"), JSIConverter<std::optional<double>>::toJSI(runtime, arg.panButtonScrollPercentage));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "onDidChangePanningInterface"), JSIConverter<std::optional<std::function<void(bool)>>>::toJSI(runtime, arg.onDidChangePanningInterface));
       return obj;
@@ -163,6 +169,7 @@ namespace margelo::nitro {
       if (!JSIConverter<std::optional<std::function<void()>>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "onAutoDriveEnabled")))) return false;
       if (!JSIConverter<std::optional<std::vector<margelo::nitro::swe::iternio::reactnativeautoplay::NitroMapButton>>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "mapButtons")))) return false;
       if (!JSIConverter<std::optional<std::vector<margelo::nitro::swe::iternio::reactnativeautoplay::NitroAction>>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "headerActions")))) return false;
+      if (!JSIConverter<std::optional<margelo::nitro::swe::iternio::reactnativeautoplay::NitroColor>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "defaultGuidanceBackgroundColor")))) return false;
       if (!JSIConverter<std::optional<double>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "panButtonScrollPercentage")))) return false;
       if (!JSIConverter<std::optional<std::function<void(bool)>>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "onDidChangePanningInterface")))) return false;
       return true;

--- a/packages/react-native-autoplay/nitrogen/generated/shared/c++/NitroLoadingManeuver.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/shared/c++/NitroLoadingManeuver.hpp
@@ -28,9 +28,12 @@
 #error NitroModules cannot be found! Are you sure you installed NitroModules properly?
 #endif
 
+// Forward declaration of `NitroColor` to properly resolve imports.
+namespace margelo::nitro::swe::iternio::reactnativeautoplay { struct NitroColor; }
 
-
-
+#include "NitroColor.hpp"
+#include <string>
+#include <optional>
 
 namespace margelo::nitro::swe::iternio::reactnativeautoplay {
 
@@ -40,10 +43,12 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
   struct NitroLoadingManeuver final {
   public:
     bool isLoading     SWIFT_PRIVATE;
+    NitroColor cardBackgroundColor     SWIFT_PRIVATE;
+    std::optional<std::string> text     SWIFT_PRIVATE;
 
   public:
     NitroLoadingManeuver() = default;
-    explicit NitroLoadingManeuver(bool isLoading): isLoading(isLoading) {}
+    explicit NitroLoadingManeuver(bool isLoading, NitroColor cardBackgroundColor, std::optional<std::string> text): isLoading(isLoading), cardBackgroundColor(cardBackgroundColor), text(text) {}
 
   public:
     friend bool operator==(const NitroLoadingManeuver& lhs, const NitroLoadingManeuver& rhs) = default;
@@ -59,12 +64,16 @@ namespace margelo::nitro {
     static inline margelo::nitro::swe::iternio::reactnativeautoplay::NitroLoadingManeuver fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
       jsi::Object obj = arg.asObject(runtime);
       return margelo::nitro::swe::iternio::reactnativeautoplay::NitroLoadingManeuver(
-        JSIConverter<bool>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "isLoading")))
+        JSIConverter<bool>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "isLoading"))),
+        JSIConverter<margelo::nitro::swe::iternio::reactnativeautoplay::NitroColor>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "cardBackgroundColor"))),
+        JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "text")))
       );
     }
     static inline jsi::Value toJSI(jsi::Runtime& runtime, const margelo::nitro::swe::iternio::reactnativeautoplay::NitroLoadingManeuver& arg) {
       jsi::Object obj(runtime);
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "isLoading"), JSIConverter<bool>::toJSI(runtime, arg.isLoading));
+      obj.setProperty(runtime, PropNameIDCache::get(runtime, "cardBackgroundColor"), JSIConverter<margelo::nitro::swe::iternio::reactnativeautoplay::NitroColor>::toJSI(runtime, arg.cardBackgroundColor));
+      obj.setProperty(runtime, PropNameIDCache::get(runtime, "text"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.text));
       return obj;
     }
     static inline bool canConvert(jsi::Runtime& runtime, const jsi::Value& value) {
@@ -76,6 +85,8 @@ namespace margelo::nitro {
         return false;
       }
       if (!JSIConverter<bool>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "isLoading")))) return false;
+      if (!JSIConverter<margelo::nitro::swe::iternio::reactnativeautoplay::NitroColor>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "cardBackgroundColor")))) return false;
+      if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "text")))) return false;
       return true;
     }
   };

--- a/packages/react-native-autoplay/package.json
+++ b/packages/react-native-autoplay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iternio/react-native-auto-play",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "Android Auto and Apple CarPlay for react-native",
   "main": "lib/index",
   "module": "lib/index",

--- a/packages/react-native-autoplay/src/templates/MapTemplate.ts
+++ b/packages/react-native-autoplay/src/templates/MapTemplate.ts
@@ -18,6 +18,7 @@ import type {
 } from '../types/Trip';
 import { type NitroAction, NitroActionUtil } from '../utils/NitroAction';
 import { type NavigationAlert, NitroAlertUtil } from '../utils/NitroAlert';
+import { type NitroColor, NitroColorUtil, type ThemedColor } from '../utils/NitroColor';
 import { NitroManeuverUtil, type NitroRoutingManeuver } from '../utils/NitroManeuver';
 import { NitroMapButton } from '../utils/NitroMapButton';
 import {
@@ -80,6 +81,8 @@ export interface NitroMapTemplateConfig extends TemplateConfig, NitroBaseMapTemp
   mapButtons?: Array<NitroMapButton>;
   headerActions?: Array<NitroAction>;
 
+  defaultGuidanceBackgroundColor?: NitroColor;
+
   /**
    * specify the percentage of screen height/width the pan button should scroll
    * @namespace iOS
@@ -131,7 +134,11 @@ export type BaseMapTemplateConfig<T> = {
 
 export type MapTemplateConfig = Omit<
   NitroMapTemplateConfig,
-  'mapButtons' | 'headerActions' | 'onStopNavigation' | 'onAutoDriveEnabled'
+  | 'mapButtons'
+  | 'headerActions'
+  | 'onStopNavigation'
+  | 'onAutoDriveEnabled'
+  | 'defaultGuidanceBackgroundColor'
 > &
   BaseMapTemplateConfig<MapTemplate> & {
     /**
@@ -150,6 +157,11 @@ export type MapTemplateConfig = Omit<
      * @namespace Android
      */
     onAutoDriveEnabled?: (template: MapTemplate) => void;
+
+    /**
+     * Initial navigation maneuver background color. Mainly useful, when in CarPlay the default loading maneuver does not have the right color.
+     */
+    defaultGuidanceBackgroundColor?: ThemedColor | string;
   };
 
 export interface TripSelectorCallback {
@@ -169,6 +181,7 @@ export class MapTemplate extends Template<MapTemplateConfig, MapTemplateConfig['
       headerActions,
       onStopNavigation,
       onAutoDriveEnabled,
+      defaultGuidanceBackgroundColor,
       ...baseConfig
     } = config;
 
@@ -197,6 +210,10 @@ export class MapTemplate extends Template<MapTemplateConfig, MapTemplateConfig['
       mapButtons: NitroMapButton.convert(this.template, mapButtons),
       onStopNavigation: () => onStopNavigation(this.template),
       onAutoDriveEnabled: onAutoDriveEnabled ? () => onAutoDriveEnabled(this.template) : undefined,
+      defaultGuidanceBackgroundColor:
+        defaultGuidanceBackgroundColor != null
+          ? NitroColorUtil.convert(defaultGuidanceBackgroundColor)
+          : undefined,
     };
 
     HybridMapTemplate.createMapTemplate(nitroConfig);
@@ -327,7 +344,11 @@ export class MapTemplate extends Template<MapTemplateConfig, MapTemplateConfig['
     }
 
     if (maneuvers.type === 'loading') {
-      HybridMapTemplate.updateManeuvers(this.id, { isLoading: true });
+      HybridMapTemplate.updateManeuvers(this.id, {
+        isLoading: true,
+        cardBackgroundColor: NitroColorUtil.convert(maneuvers.cardBackgroundColor),
+        text: maneuvers.text != null ? maneuvers.text : undefined,
+      });
       return;
     }
 

--- a/packages/react-native-autoplay/src/types/Maneuver.ts
+++ b/packages/react-native-autoplay/src/types/Maneuver.ts
@@ -252,6 +252,12 @@ export type MessageManeuver = {
 
 export type LoadingManeuver = {
   type: 'loading';
+  cardBackgroundColor: ThemedColor | string;
+  /**
+   * @namespace iOS CarPlay — shows text on the loading maneuver card
+   * @namespace Android Auto — not supported
+   */
+  text?: string;
 };
 
 export type AutoManeuver =

--- a/packages/react-native-autoplay/src/utils/NitroManeuver.ts
+++ b/packages/react-native-autoplay/src/utils/NitroManeuver.ts
@@ -54,6 +54,8 @@ export interface NitroMessageManeuver {
 
 interface NitroLoadingManeuver {
   isLoading: true;
+  cardBackgroundColor: NitroColor;
+  text?: string;
 }
 
 export type NitroManeuver =


### PR DESCRIPTION
Since iOS 26.4 (or maybe slightly earlier already, but 26.x) the loading (paused trip) maneuver changed to an alarming red background color. This allows to overwrite the color now, by providing the defaulkt background color. Also allows changing the "Loading..." text to whatever text we want.

Background color on Android is applied too, but text does not work.