### PR TITLE
fix: defensively release virtualDisplay before creation

### DIFF
--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/VirtualRenderer.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/VirtualRenderer.kt
@@ -78,6 +78,7 @@ class VirtualRenderer(
                 }
 
                 val manager = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+                virtualDisplay?.release()
                 virtualDisplay = manager.createVirtualDisplay(
                     moduleName,
                     surfaceContainer.width,


### PR DESCRIPTION
In pathological cases, `onSurfaceDestroyed` is never called and the cleanup in `onSurfaceDestroyed` (`virtualDisplay?.release()`) never runs. Each call to `onSurfaceAvailable` orphans the previous `VirtualDisplay` that remains alive consuming framebuffers, but with no reference to release it.

This is likely a bug higher up in the stack (CarAppActivity), but good to protect against it.

I encountered this issue when running ABRP on Android Automotive, repeated `onSurfaceAvailable` callbacks without corresponding `onSurfaceDestroyed` callbacks cause `VirtualDisplay` instances to leak in `VirtualRenderer.kt`. Each leaked virtual display exhausts GPU resources and `surfaceflinger` eventually crashes when it tries to create a texture with:

```
Failed to create a valid texture. [0xb400007ad86b25f0]:[2640,1416] isProtected:0 isWriteable:0 format:1
Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid 1153 (RenderEngine), pid 1032 (surfaceflinger)
```

Reproduced with something like:

```
   for i in $(seq 1 100); do
       adb shell am start -n com.iternio.abrpapp/androidx.car.app.activity.CarAppActivity \
           -a android.intent.action.MAIN -c android.intent.category.LAUNCHER \
           --activity-single-top
       sleep 1
   done
```

and monitored increasing  virtual displays with 
```  
adb shell dumpsys display | grep -c "AutoPlayRoot"
```

