### PR TITLE
Bring back themed context for automotive

### DIFF
--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/VirtualRenderer.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/VirtualRenderer.kt
@@ -7,6 +7,7 @@ import android.graphics.Rect
 import android.hardware.display.DisplayManager
 import android.hardware.display.VirtualDisplay
 import android.os.Bundle
+import android.view.ContextThemeWrapper
 import android.view.Display
 import android.view.LayoutInflater
 import android.view.View
@@ -282,8 +283,14 @@ class VirtualRenderer(
         override fun onCreate(savedInstanceState: Bundle?) {
             super.onCreate(savedInstanceState)
 
+            // Wrap applicationContext with the app theme so AppCompat widgets (e.g. ReactTextView)
+            // can resolve their required text-appearance attrs on OEM themes that don't define them
+            // (notably Polestar/Volvo Android Automotive: Theme.DeviceDefault.Light.DarkActionBar).
+            val appTheme = context.applicationContext.applicationInfo.theme
+            val themedContext = ContextThemeWrapper(context.applicationContext, appTheme)
+
             if (!this@VirtualRenderer::reactSurfaceImpl.isInitialized) {
-                reactSurfaceImpl = ReactSurfaceImpl(context, moduleName, initialProperties)
+                reactSurfaceImpl = ReactSurfaceImpl(themedContext, moduleName, initialProperties)
             }
 
             var splashScreenView: View? = null
@@ -292,9 +299,9 @@ class VirtualRenderer(
                 (it.parent as ViewGroup).removeView(it)
             } ?: run {
                 splashScreenView =
-                    if (isCluster) getClusterSplashScreen(context, height, width) else null
+                    if (isCluster) getClusterSplashScreen(themedContext, height, width) else null
 
-                val surfaceView = ReactSurfaceView(context, reactSurfaceImpl).apply {
+                val surfaceView = ReactSurfaceView(themedContext, reactSurfaceImpl).apply {
                     layoutParams = FrameLayout.LayoutParams(
                         (width / reactNativeScale).toInt(), (height / reactNativeScale).toInt()
                     )
@@ -330,7 +337,7 @@ class VirtualRenderer(
             }
 
 
-            val rootContainer = FrameLayout(context).apply {
+            val rootContainer = FrameLayout(themedContext).apply {
                 layoutParams = FrameLayout.LayoutParams(
                     FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT
                 )

--- a/packages/react-native-autoplay/package.json
+++ b/packages/react-native-autoplay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iternio/react-native-auto-play",
-  "version": "0.4.4",
+  "version": "0.4.6",
   "description": "Android Auto and Apple CarPlay for react-native",
   "main": "lib/index",
   "module": "lib/index",


### PR DESCRIPTION
We had this fix on 0.3.7, but it got lost on the refactoring to version 0.3.8 in [fbe7863](https://github.com/Iternio-Planning-AB/react-native-auto-play/commit/fbe7863)

This adds it back now.

Hard to reproduce with simulators, but it didn't break anything so it probably still works.