### PR TITLE
fix: register CarPlayDashboard before dashboard connects

### DIFF
--- a/packages/react-native-autoplay/src/scenes/CarPlayDashboardScene.ts
+++ b/packages/react-native-autoplay/src/scenes/CarPlayDashboardScene.ts
@@ -25,6 +25,7 @@ export type CarPlayDashboardEvent = EventName | VisibilityState;
 
 class Dashboard {
   private component: React.ComponentType<RootComponentInitialProps> | null = null;
+  private componentRegistered = false;
   public isConnected = false;
   public readonly id = 'CarPlayDashboard';
 
@@ -47,20 +48,26 @@ class Dashboard {
     }
 
     const { component, isConnected } = this;
-    if (!isConnected || component == null) {
+    if (component == null) {
       return;
     }
 
-    AppRegistry.registerComponent(
-      this.id,
-      () => (props) =>
-        React.createElement(SafeAreaInsetsProvider, {
-          moduleName: this.id,
-          // biome-ignore lint/correctness/noChildrenProp: there is no other way in a ts file
-          children: React.createElement(component, props),
-        })
-    );
-    HybridCarPlayDashboard.initRootView();
+    if (!this.componentRegistered) {
+      AppRegistry.registerComponent(
+        this.id,
+        () => (props) =>
+          React.createElement(SafeAreaInsetsProvider, {
+            moduleName: this.id,
+            // biome-ignore lint/correctness/noChildrenProp: there is no other way in a ts file
+            children: React.createElement(component, props),
+          })
+      );
+      this.componentRegistered = true;
+    }
+
+    if (isConnected) {
+      HybridCarPlayDashboard.initRootView();
+    }
   }
 
   public setComponent(component: React.ComponentType<RootComponentInitialProps>) {


### PR DESCRIPTION
## Problem

`CarPlayDashboard` is currently only registered with React Native's `AppRegistry` after the dashboard scene reports `didConnect`.

That makes the dashboard root component registration depend on the CarPlay connection lifecycle. In some reload/reconnect flows, the native dashboard scene can request a React root view for the `CarPlayDashboard` module before JS has received a fresh `didConnect` event again.

In that case React Native throws:

```text
Invariant Violation: "CarPlayDashboard" has not been registered.
```

## Reproduction

In a consuming app using `CarPlayDashboard.setComponent(...)`:

1. Start the app with CarPlay enabled.
2. Open the CarPlay Dashboard scene.
3. Close/disconnect the CarPlay scene.
4. Reload the React Native app / Metro while the dashboard scene lifecycle is still around or reconnect CarPlay afterwards.
5. The native side can try to create a root view for `CarPlayDashboard` before JS registers the component again.

Observed result:

```text
"CarPlayDashboard" has not been registered
```

Expected result:

`CarPlayDashboard` should be registered once the JS component is provided via `setComponent(...)`. Native root view initialization should still only happen while the dashboard scene is connected.

## What Changed

- Register the `CarPlayDashboard` component as soon as `setComponent(...)` has provided the component.
- Keep `HybridCarPlayDashboard.initRootView()` guarded by the current `isConnected` state.
- Add a small `componentRegistered` guard so reconnects do not repeatedly call `AppRegistry.registerComponent(...)`.

## Why

`AppRegistry.registerComponent(...)` is JS runtime setup and does not need an active CarPlay Dashboard connection.

`initRootView()` is the part that needs the native dashboard scene/window to be connected, so that remains connection-gated.

This keeps the existing native lifecycle behavior intact while making the JS module registration deterministic across reloads and reconnects.

## Testing

- Verified in a consuming app that the iOS simulator build succeeds.
- Verified that `CarPlayDashboard` is registered before native dashboard root view initialization is requested.
- Existing dashboard initialization still only calls `initRootView()` when the dashboard is connected.
