### PR TITLE
feat: add isCarServiceRunning() to distinguish headless start sources

### DIFF
--- a/apps/example/index_with_headless.js
+++ b/apps/example/index_with_headless.js
@@ -1,0 +1,71 @@
+/**
+ * This is an alternative entry point that demonstrates how to use
+ * HybridAutoPlay.isCarServiceRunning() to prevent heavy JS initialization
+ * during notification-only headless starts on Android.
+ *
+ * Problem:
+ * On Android, both Android Auto and Firebase notifications can start the app
+ * process headlessly. In both cases index.js executes and all top-level imports
+ * are evaluated eagerly — including the Redux store, middleware, and other side
+ * effects. These keep the process alive after the notification is handled,
+ * wasting resources and battery.
+ *
+ * Solution:
+ * Use isCarServiceRunning() to distinguish between headless starts triggered by
+ * Android Auto / CarPlay and those triggered by other sources (e.g. notifications).
+ * Heavy modules are loaded via lazy require() calls that only execute when actually
+ * needed — either when the car service is running, when the user opens the app
+ * (Activity triggers runApplication), or when AA/CP connects later.
+ *
+ * Scenarios:
+ * 1. App starts first, then AA/CP connects:
+ *    - else branch taken, lazy component provider registered
+ *    - Activity renders -> provider executes, loads store/App/car listeners
+ *    - didConnect fires later -> car templates created
+ *
+ * 2. AA/CP starts without app open (headless):
+ *    - if branch taken, everything loads immediately
+ *    - Car UI works, phone UI mounts later if Activity starts
+ *
+ * 3. Notification comes in, no app, no AA/CP:
+ *    - else branch taken, but component provider never called (no Activity)
+ *    - didConnect never fires (no car)
+ *    - No require() calls execute -> store/middleware never load -> clean exit
+ *
+ * 4. Notification comes in, then app or AA/CP starts shortly after:
+ *    - else branch taken initially (lightweight)
+ *    - Activity or didConnect triggers lazy loading when needed
+ */
+
+import React from 'react';
+import { AppRegistry } from 'react-native';
+import { HybridAutoPlay } from '@iternio/react-native-auto-play';
+import { name as appName } from './app.json';
+
+let carListenersInitialized = false;
+
+function initCarListeners() {
+  if (carListenersInitialized) return;
+  carListenersInitialized = true;
+  const registerRunnable = require('./src/AutoPlay').default;
+  registerRunnable();
+}
+
+if (HybridAutoPlay.isCarServiceRunning()) {
+  const { StateWrapper } = require('./src/state/store');
+  const App = require('./src/App').default;
+
+  AppRegistry.setWrapperComponentProvider(() => StateWrapper);
+  AppRegistry.registerComponent(appName, () => App);
+  initCarListeners();
+} else {
+  AppRegistry.registerComponent(appName, () => {
+    const { StateWrapper } = require('./src/state/store');
+    const App = require('./src/App').default;
+    initCarListeners();
+    return (props) =>
+      React.createElement(StateWrapper, null, React.createElement(App, props));
+  });
+
+  HybridAutoPlay.addListener('didConnect', initCarListeners);
+}

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridAutoPlay.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridAutoPlay.kt
@@ -45,6 +45,10 @@ class HybridAutoPlay : HybridAutoPlaySpec() {
         return AndroidAutoSession.getIsConnected()
     }
 
+    override fun isCarServiceRunning(): Boolean {
+        return AndroidAutoService.instance != null
+    }
+
     override fun addListenerRenderState(
         moduleName: String, callback: (VisibilityState) -> Unit
     ): () -> Unit {

--- a/packages/react-native-autoplay/ios/hybrid/HybridAutoPlay.swift
+++ b/packages/react-native-autoplay/ios/hybrid/HybridAutoPlay.swift
@@ -83,6 +83,10 @@ class HybridAutoPlay: HybridAutoPlaySpec {
         return SceneStore.isRootModuleConnected()
     }
 
+    func isCarServiceRunning() throws -> Bool {
+        return SceneStore.isRootModuleConnected()
+    }
+
     func addSafeAreaInsetsListener(
         moduleName: String,
         callback: @escaping (SafeAreaInsets) -> Void

--- a/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridAutoPlaySpec.cpp
+++ b/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridAutoPlaySpec.cpp
@@ -303,5 +303,10 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
     auto __result = method(_javaPart);
     return static_cast<bool>(__result);
   }
+  bool JHybridAutoPlaySpec::isCarServiceRunning() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jboolean()>("isCarServiceRunning");
+    auto __result = method(_javaPart);
+    return static_cast<bool>(__result);
+  }
 
 } // namespace margelo::nitro::swe::iternio::reactnativeautoplay

--- a/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridAutoPlaySpec.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/android/c++/JHybridAutoPlaySpec.hpp
@@ -69,6 +69,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
     std::function<void()> addSafeAreaInsetsListener(const std::string& moduleName, const std::function<void(const SafeAreaInsets& /* insets */)>& callback) override;
     std::shared_ptr<Promise<void>> setTemplateHeaderActions(const std::string& templateId, const std::optional<std::vector<NitroAction>>& headerActions) override;
     bool isConnected() override;
+    bool isCarServiceRunning() override;
 
   private:
     jni::global_ref<JHybridAutoPlaySpec::JavaPart> _javaPart;

--- a/packages/react-native-autoplay/nitrogen/generated/android/kotlin/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridAutoPlaySpec.kt
+++ b/packages/react-native-autoplay/nitrogen/generated/android/kotlin/com/margelo/nitro/swe/iternio/reactnativeautoplay/HybridAutoPlaySpec.kt
@@ -109,6 +109,10 @@ abstract class HybridAutoPlaySpec: HybridObject() {
   @DoNotStrip
   @Keep
   abstract fun isConnected(): Boolean
+  
+  @DoNotStrip
+  @Keep
+  abstract fun isCarServiceRunning(): Boolean
 
   // Default implementation of `HybridObject.toString()`
   override fun toString(): String {

--- a/packages/react-native-autoplay/nitrogen/generated/ios/c++/HybridAutoPlaySpecSwift.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/c++/HybridAutoPlaySpecSwift.hpp
@@ -228,6 +228,14 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
       auto __value = std::move(__result.value());
       return __value;
     }
+    inline bool isCarServiceRunning() override {
+      auto __result = _swiftPart.isCarServiceRunning();
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
 
   private:
     ReactNativeAutoPlay::HybridAutoPlaySpec_cxx _swiftPart;

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridAutoPlaySpec.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridAutoPlaySpec.swift
@@ -28,6 +28,7 @@ public protocol HybridAutoPlaySpec_protocol: HybridObject {
   func addSafeAreaInsetsListener(moduleName: String, callback: @escaping (_ insets: SafeAreaInsets) -> Void) throws -> () -> Void
   func setTemplateHeaderActions(templateId: String, headerActions: [NitroAction]?) throws -> Promise<Void>
   func isConnected() throws -> Bool
+  func isCarServiceRunning() throws -> Bool
 }
 
 public extension HybridAutoPlaySpec_protocol {

--- a/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridAutoPlaySpec_cxx.swift
+++ b/packages/react-native-autoplay/nitrogen/generated/ios/swift/HybridAutoPlaySpec_cxx.swift
@@ -451,4 +451,16 @@ open class HybridAutoPlaySpec_cxx {
       return bridge.create_Result_bool_(__exceptionPtr)
     }
   }
+  
+  @inline(__always)
+  public final func isCarServiceRunning() -> bridge.Result_bool_ {
+    do {
+      let __result = try self.__implementation.isCarServiceRunning()
+      let __resultCpp = __result
+      return bridge.create_Result_bool_(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_bool_(__exceptionPtr)
+    }
+  }
 }

--- a/packages/react-native-autoplay/nitrogen/generated/shared/c++/HybridAutoPlaySpec.cpp
+++ b/packages/react-native-autoplay/nitrogen/generated/shared/c++/HybridAutoPlaySpec.cpp
@@ -29,6 +29,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
       prototype.registerHybridMethod("addSafeAreaInsetsListener", &HybridAutoPlaySpec::addSafeAreaInsetsListener);
       prototype.registerHybridMethod("setTemplateHeaderActions", &HybridAutoPlaySpec::setTemplateHeaderActions);
       prototype.registerHybridMethod("isConnected", &HybridAutoPlaySpec::isConnected);
+      prototype.registerHybridMethod("isCarServiceRunning", &HybridAutoPlaySpec::isCarServiceRunning);
     });
   }
 

--- a/packages/react-native-autoplay/nitrogen/generated/shared/c++/HybridAutoPlaySpec.hpp
+++ b/packages/react-native-autoplay/nitrogen/generated/shared/c++/HybridAutoPlaySpec.hpp
@@ -82,6 +82,7 @@ namespace margelo::nitro::swe::iternio::reactnativeautoplay {
       virtual std::function<void()> addSafeAreaInsetsListener(const std::string& moduleName, const std::function<void(const SafeAreaInsets& /* insets */)>& callback) = 0;
       virtual std::shared_ptr<Promise<void>> setTemplateHeaderActions(const std::string& templateId, const std::optional<std::vector<NitroAction>>& headerActions) = 0;
       virtual bool isConnected() = 0;
+      virtual bool isCarServiceRunning() = 0;
 
     protected:
       // Hybrid Setup

--- a/packages/react-native-autoplay/src/specs/AutoPlay.nitro.ts
+++ b/packages/react-native-autoplay/src/specs/AutoPlay.nitro.ts
@@ -131,11 +131,9 @@ export interface AutoPlay extends HybridObject<{ android: 'kotlin'; ios: 'swift'
   isConnected(): boolean;
 
   /**
-   * Check if the native CarAppService (Android Auto) is currently running.
-   * Use this to distinguish a headless execution triggered by Android Auto
+   * Check if the native AutoPlay is currently running.
+   * Use this to distinguish a headless execution triggered by AA / CP
    * from one triggered by other sources (e.g. notification updates).
-   * On iOS this always returns false.
-   * @namespace Android
    */
   isCarServiceRunning(): boolean;
 }

--- a/packages/react-native-autoplay/src/specs/AutoPlay.nitro.ts
+++ b/packages/react-native-autoplay/src/specs/AutoPlay.nitro.ts
@@ -129,4 +129,13 @@ export interface AutoPlay extends HybridObject<{ android: 'kotlin'; ios: 'swift'
    * @returns true if AutoPlay is connected, false otherwise.
    */
   isConnected(): boolean;
+
+  /**
+   * Check if the native CarAppService (Android Auto) is currently running.
+   * Use this to distinguish a headless execution triggered by Android Auto
+   * from one triggered by other sources (e.g. notification updates).
+   * On iOS this always returns false.
+   * @namespace Android
+   */
+  isCarServiceRunning(): boolean;
 }


### PR DESCRIPTION
## Summary

- Adds `isCarServiceRunning(): boolean` to the `AutoPlay` NitroModules spec, allowing apps to synchronously check whether the native car service (Android Auto's `CarAppService` or iOS's CarPlay scene) triggered the current headless execution.
- On Android, checks `AndroidAutoService.instance != null` — true as soon as the `CarAppService` is alive, before the session is fully established.
- On iOS, checks `SceneStore.isRootModuleConnected()` — true when the CarPlay scene is connected.

## Motivation

On Android, both Android Auto and other services (e.g. Firebase notifications) can start the app process headlessly. Until now there was no way to distinguish which source triggered the start. This made it impossible to skip heavy JS initialization (Redux store, middleware, subscriptions) during notification-only headless starts, causing the process to stay alive unnecessarily and waste battery.

`isCarServiceRunning()` is available immediately at startup before any component renders, allowing apps to gate their initialization in `index.js` using lazy `require()` calls.

## Usage

```js
import { HybridAutoPlay } from '@iternio/react-native-auto-play';

if (HybridAutoPlay.isCarServiceRunning()) {
  // AA/CP started the app — full initialization
} else {
  // Notification or other headless start — defer heavy imports
}
```

See `apps/example/index_with_headless.js` for a complete reference implementation covering all scenarios (notification-only, car headless, normal launch, late car connection).

## Test plan

- [x] Start Android Auto headlessly — verify `isCarServiceRunning()` returns `true`
- [x] Start app via notification without AA/CP — verify it returns `false`
- [x] Start app normally (tap icon) — verify it returns `false`
- [x] Connect CarPlay on iOS — verify it returns `true`
- [x] Verify `index_with_headless.js` pattern works for all four scenarios


Made with [Cursor](https://cursor.com)