### PR TITLE
Crucial ProGuard rule info

### DIFF
--- a/packages/react-native-autoplay/README.md
+++ b/packages/react-native-autoplay/README.md
@@ -200,7 +200,7 @@ No platform specific setup required - we got you covered with all the required s
 In case you have ProGuard enabled (`def enableProguardInReleaseBuilds = true` in `android/app/build.gradle`), add the following rule to `android/app/proguard-rules.pro`:
 
 ```
--keep class com.margelo.nitro.swe.iternio.reactnativeautoplay.** { *; }`
+-keep class com.margelo.nitro.swe.iternio.reactnativeautoplay.** { *; }
 ```
 
 ### Android Auto Customization

--- a/packages/react-native-autoplay/README.md
+++ b/packages/react-native-autoplay/README.md
@@ -196,6 +196,13 @@ In case you wanna open up your CarPlay app from one of the CarPlay dashboard but
 ### Android Auto
 No platform specific setup required - we got you covered with all the required stuff.
 
+#### ProGuard
+In case you have ProGuard enabled (`def enableProguardInReleaseBuilds = true` in `android/app/build.gradle`), add the following rule to `packages/mobile-app/android/app/proguard-rules.pro`:
+
+```
+-keep class com.margelo.nitro.swe.iternio.reactnativeautoplay.** { *; }`
+```
+
 ### Android Auto Customization
 You can customize certain behaviors of the library on Android Auto by setting properties in your app's `android/gradle.properties` file.
 

--- a/packages/react-native-autoplay/README.md
+++ b/packages/react-native-autoplay/README.md
@@ -197,7 +197,7 @@ In case you wanna open up your CarPlay app from one of the CarPlay dashboard but
 No platform specific setup required - we got you covered with all the required stuff.
 
 #### ProGuard
-In case you have ProGuard enabled (`def enableProguardInReleaseBuilds = true` in `android/app/build.gradle`), add the following rule to `packages/mobile-app/android/app/proguard-rules.pro`:
+In case you have ProGuard enabled (`def enableProguardInReleaseBuilds = true` in `android/app/build.gradle`), add the following rule to `android/app/proguard-rules.pro`:
 
 ```
 -keep class com.margelo.nitro.swe.iternio.reactnativeautoplay.** { *; }`


### PR DESCRIPTION
Adding ProGuard rule is crucial to avoid startup crash in release mode when `def enableProguardInReleaseBuilds` is set to  `true`