### PR TITLE
fix: telemetry observers executing on main thread

### DIFF
--- a/packages/react-native-autoplay/android/src/auto/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/AndroidTelemetryObserver.kt
+++ b/packages/react-native-autoplay/android/src/auto/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/AndroidTelemetryObserver.kt
@@ -9,7 +9,6 @@ import androidx.car.app.hardware.info.Mileage
 import androidx.car.app.hardware.info.Model
 import androidx.car.app.hardware.info.Speed
 import androidx.car.app.versioning.CarAppApiLevels
-import androidx.core.content.ContextCompat
 
 object AndroidTelemetryObserver : TelemetryObserver() {
     private var carContext: CarContext? = null
@@ -81,8 +80,6 @@ object AndroidTelemetryObserver : TelemetryObserver() {
             throw UnsupportedOperationException("Telemetry not supported for this API level ${carContext.carAppApiLevel}")
         }
 
-        val carHardwareExecutor = ContextCompat.getMainExecutor(carContext)
-
         val carHardwareManager = carContext.getCarService(
             CarHardwareManager::class.java
         )
@@ -90,7 +87,7 @@ object AndroidTelemetryObserver : TelemetryObserver() {
 
         // Request any single shot values.
         try {
-            carInfo.fetchModel(carHardwareExecutor, mModelListener)
+            carInfo.fetchModel(telemetryExecutor, mModelListener)
         } catch (_: SecurityException) {
         } catch (_: NullPointerException) {
         }
@@ -102,19 +99,19 @@ object AndroidTelemetryObserver : TelemetryObserver() {
         }
 
         try {
-            carInfo.addEnergyLevelListener(carHardwareExecutor, mEnergyLevelListener)
+            carInfo.addEnergyLevelListener(telemetryExecutor, mEnergyLevelListener)
         } catch (_: SecurityException) {
         } catch (_: NullPointerException) {
         }
 
         try {
-            carInfo.addSpeedListener(carHardwareExecutor, mSpeedListener)
+            carInfo.addSpeedListener(telemetryExecutor, mSpeedListener)
         } catch (_: SecurityException) {
         } catch (_: NullPointerException) {
         }
 
         try {
-            carInfo.addMileageListener(carHardwareExecutor, mMileageListener)
+            carInfo.addMileageListener(telemetryExecutor, mMileageListener)
         } catch (_: SecurityException) {
         } catch (_: NullPointerException) {
         }

--- a/packages/react-native-autoplay/android/src/automotive/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/AndroidTelemetryObserver.kt
+++ b/packages/react-native-autoplay/android/src/automotive/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/AndroidTelemetryObserver.kt
@@ -160,7 +160,7 @@ object AndroidTelemetryObserver : TelemetryObserver() {
         // create new instance so we can access all props after permissions were granted
         mCar?.disconnect()
 
-        val car = Car.createCar(NitroModules.applicationContext)
+        val car = Car.createCar(NitroModules.applicationContext, handler)
         mCar = car
 
         fetchStaticData(car)

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/TelemetryObserver.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/TelemetryObserver.kt
@@ -3,6 +3,7 @@ package com.margelo.nitro.swe.iternio.reactnativeautoplay
 import android.os.Handler
 import android.os.HandlerThread
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executor
 
 abstract class TelemetryObserver {
     abstract fun startTelemetryObserver(): Boolean
@@ -12,11 +13,16 @@ abstract class TelemetryObserver {
     val telemetryHolder = AndroidAutoTelemetryHolder()
     var isObserverRunning = false
     val handler: Handler
+    val telemetryExecutor: Executor
 
     init {
         val thread = HandlerThread("AndroidTelemetryThread")
         thread.start()
         handler = Handler(thread.looper)
+
+        telemetryExecutor = Executor { command ->
+            handler.post(command)
+        }
     }
 
     fun addListener(callback: (Telemetry?) -> Unit): () -> Unit {


### PR DESCRIPTION
This PR makes sure the callbacks for Android Auto and Android Automotive telemetry data are run on the proper AndroidTelemetryThread thread instead of the main thread.