### PR TITLE
ci: use ANTHROPIC_API_KEY for claude-code-action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
The `@claude` review workflow fails instantly since 2026-07-14 — the first API request is rejected, pointing at the `CLAUDE_CODE_OAUTH_TOKEN` (created 2026-05-19) no longer being accepted, while the identical setup last succeeded on 2026-07-09.

Switch the action to `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}`.

**Before merging:** set the `ANTHROPIC_API_KEY` repo secret. Note `issue_comment` workflows run from `master`, so this takes effect once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)