### PR TITLE
fix: stop Android Auto session/renderer lifecycle leaks

### DIFF
--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/AndroidAutoSession.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/AndroidAutoSession.kt
@@ -208,6 +208,8 @@ class AndroidAutoSession(sessionInfo: SessionInfo) :
         }
 
         override fun onDestroy(owner: LifecycleOwner) {
+            NitroModules.applicationContext?.removeLifecycleEventListener(reactLifecycleObserver)
+
             sessions.remove(moduleName)
             VirtualRenderer.removeRenderer(moduleName)
             clusterId?.let {

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/VirtualRenderer.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/VirtualRenderer.kt
@@ -22,6 +22,7 @@ import androidx.car.app.SurfaceCallback
 import androidx.car.app.SurfaceContainer
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactContext
+import com.facebook.react.common.LifecycleState
 import com.facebook.react.fabric.FabricUIManager
 import com.facebook.react.runtime.ReactSurfaceImpl
 import com.facebook.react.runtime.ReactSurfaceView
@@ -420,6 +421,22 @@ class VirtualRenderer(
             // Fabric already invalidated
         } finally {
             reactSurfaceId = null
+
+            // once the last active renderer (main map, dashboard, cluster) is stopped, restore the
+            // ui-manager's lifecycle listener that was removed in FabricMapPresentation.onCreate so
+            // the app's own frame callback pauses/resumes with the phone app's foreground state again
+            if (virtualRenderer.size <= 1) {
+                val reactContext = NitroModules.applicationContext
+                if (reactContext != null && uiManager != null) {
+                    reactContext.removeLifecycleEventListener(uiManager)
+                    reactContext.addLifecycleEventListener(uiManager)
+
+                    if (reactContext.lifecycleState != LifecycleState.RESUMED) {
+                        uiManager.onHostPause()
+                    }
+                }
+            }
+
             virtualRenderer.remove(moduleName)
         }
     }


### PR DESCRIPTION
## Summary
- `AndroidAutoSession` never removed its `LifecycleEventListener` on disconnect — each connect/disconnect cycle (including cluster sessions) leaked one listener that retains the session and its `CarContext` for the life of the process, and stale leaked observers later call `finishCarApp()` on a dead `CarContext`.
- `VirtualRenderer` intentionally unhooks `FabricUIManager` from the React host lifecycle so the car display keeps rendering while the phone app is backgrounded, but never re-hooked it once the last renderer stopped — so Fabric's per-frame Choreographer callback kept firing in the background indefinitely after any Android Auto session, for the rest of the process lifetime.

## Fixes
- `AndroidAutoSession.onDestroy` now removes `reactLifecycleObserver` before the cluster/root branch so it runs on both paths.
- `VirtualRenderer.stop()` now restores the `FabricUIManager` lifecycle listener once `virtualRenderer` becomes empty (i.e. the last active renderer — main map, dashboard, or cluster), and synchronously calls `onHostPause()` if the React context isn't currently `RESUMED`, since `addLifecycleEventListener` only replays `onHostResume`, never `onHostPause`.

## Test plan
- [x] Compiles cleanly (`:iternio_react-native-auto-play:compileDebugKotlin`)
- [x] `yarn lint:auto-play` passes
- [ ] Manual verification on a real head unit/emulator: AA connect → phone backgrounded → car keeps rendering; AA connect → disconnect → phone backgrounded → Fabric frame callback pauses; multi-renderer (cluster + main) ordering; reconnect cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)