### PR TITLE
Permit non-navigation Android Auto app types

### DIFF
--- a/packages/react-native-autoplay/README.md
+++ b/packages/react-native-autoplay/README.md
@@ -206,6 +206,12 @@ In case you have ProGuard enabled (`def enableProguardInReleaseBuilds = true` in
 ### Android Auto Customization
 You can customize certain behaviors of the library on Android Auto by setting properties in your app's `android/gradle.properties` file.
 
+-   **App Category**: Declare which Android Auto / Automotive app type the `CarAppService` advertises — the Android counterpart to choosing your CarPlay scene type in `Info.plist`.
+    ```properties
+    ReactNativeAutoPlay_androidAutoAppCategory=navigation
+    ```
+    The value maps to `androidx.car.app.category.<UPPERCASE>` (e.g. `navigation`, `poi`, `parking`, `charging`) — see the [supported app categories](https://developer.android.com/training/cars). The default `navigation` keeps the existing behavior. Any other value selects a lean manifest that declares the chosen category and omits the navigation-only permissions (`NAVIGATION_TEMPLATES`, `MAP_TEMPLATES`, `ACCESS_SURFACE`), the `FEATURE_CLUSTER` category, and the `NAVIGATE`/`geo` intent filters — a non-navigation, no-map template app needs none of these, and declaring them gets the app reviewed against the navigation-app bar on the Play Store.
+
 -   **Telemetry Update Interval**: Control how often telemetry data is updated.
     ```properties
     ReactNativeAutoPlay_androidTelemetryUpdateInterval=4000

--- a/packages/react-native-autoplay/README.md
+++ b/packages/react-native-autoplay/README.md
@@ -210,7 +210,9 @@ You can customize certain behaviors of the library on Android Auto by setting pr
     ```properties
     ReactNativeAutoPlay_androidAutoAppCategory=navigation
     ```
-    The value maps to `androidx.car.app.category.<UPPERCASE>` (e.g. `navigation`, `poi`, `parking`, `charging`) — see the [supported app categories](https://developer.android.com/training/cars). The default `navigation` keeps the existing behavior. Any other value selects a lean manifest that declares the chosen category and omits the navigation-only permissions (`NAVIGATION_TEMPLATES`, `MAP_TEMPLATES`, `ACCESS_SURFACE`), the `FEATURE_CLUSTER` category, and the `NAVIGATE`/`geo` intent filters — a non-navigation, no-map template app needs none of these, and declaring them gets the app reviewed against the navigation-app bar on the Play Store.
+    Supported values are `navigation`, `poi`, `parking`, `charging`, `iot`, `messaging`, `calling`, and `weather` (see the [supported app categories](https://developer.android.com/training/cars)); each maps to `androidx.car.app.category.<UPPERCASE>`. An unrecognized value fails the build. The default `navigation` keeps the existing behavior. Any other value selects a lean manifest that declares the chosen category and omits the navigation-only permissions (`NAVIGATION_TEMPLATES`, `MAP_TEMPLATES`, `ACCESS_SURFACE`), the `FEATURE_CLUSTER` category, and the `NAVIGATE`/`geo` intent filters — a non-navigation, no-map template app needs none of these, and declaring them gets the app reviewed against the navigation-app bar on the Play Store.
+
+    On Android Automotive, the app-focus helpers on `HybridAndroidAutomotive` (`requestAppFocus`, `registerAppFocusListener`, `getAppFocusState`) request/observe **navigation** focus specifically; they are meant for navigation apps and should not be used with a non-navigation category.
 
 -   **Telemetry Update Interval**: Control how often telemetry data is updated.
     ```properties

--- a/packages/react-native-autoplay/android/build.gradle
+++ b/packages/react-native-autoplay/android/build.gradle
@@ -28,6 +28,10 @@ def getExtOrIntegerDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties["ReactNativeAutoPlay_" + name]).toInteger()
 }
 
+// Non-navigation categories select the lean manifest (AndroidManifest-nonnav.xml).
+def androidAutoAppCategory = getExtOrDefault("androidAutoAppCategory").toString().trim()
+def isNavigationApp = androidAutoAppCategory.equalsIgnoreCase("navigation")
+
 android {
   namespace "com.margelo.nitro.swe.iternio.reactnativeautoplay"
 
@@ -54,6 +58,8 @@ android {
         }
       }
     }
+
+    manifestPlaceholders.autoPlayAppCategory = "androidx.car.app.category." + androidAutoAppCategory.toUpperCase()
 
     buildConfigField "float", "SCALE_FACTOR", getExtOrDefault("androidAutoScaleFactor")
     buildConfigField "long", "TELEMETRY_UPDATE_INTERVAL", getExtOrDefault("androidTelemetryUpdateInterval")
@@ -117,10 +123,10 @@ android {
 
       if (getExtOrDefault("isAutomotiveApp") == "true") {
         java.srcDirs += 'src/automotive/java'
-        manifest.srcFile 'src/automotive/AndroidManifest.xml'
+        manifest.srcFile isNavigationApp ? 'src/automotive/AndroidManifest.xml' : 'src/automotive/AndroidManifest-nonnav.xml'
       } else {
         java.srcDirs += 'src/auto/java'
-        manifest.srcFile 'src/main/AndroidManifest.xml'
+        manifest.srcFile isNavigationApp ? 'src/main/AndroidManifest.xml' : 'src/main/AndroidManifest-nonnav.xml'
       }
     }
   }

--- a/packages/react-native-autoplay/android/build.gradle
+++ b/packages/react-native-autoplay/android/build.gradle
@@ -29,8 +29,9 @@ def getExtOrIntegerDefault(name) {
 }
 
 // Non-navigation categories select the lean manifest (AndroidManifest-nonnav.xml).
-def androidAutoAppCategory = getExtOrDefault("androidAutoAppCategory").toString().trim()
-def isNavigationApp = androidAutoAppCategory.equalsIgnoreCase("navigation")
+def androidAutoAppCategory = getExtOrDefault("androidAutoAppCategory").toString().trim().toLowerCase(java.util.Locale.ROOT)
+def validAndroidAutoCategories = ['navigation', 'poi', 'parking', 'charging', 'iot', 'messaging', 'calling', 'weather']
+def isNavigationApp = androidAutoAppCategory == "navigation"
 
 android {
   namespace "com.margelo.nitro.swe.iternio.reactnativeautoplay"
@@ -39,6 +40,10 @@ android {
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
 
   defaultConfig {
+    if (!validAndroidAutoCategories.contains(androidAutoAppCategory)) {
+      throw new GradleException("Invalid ReactNativeAutoPlay_androidAutoAppCategory '${androidAutoAppCategory}'. Must be one of: ${validAndroidAutoCategories.join(', ')}")
+    }
+
     minSdkVersion getExtOrIntegerDefault("minSdkVersion")
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
 
@@ -59,8 +64,9 @@ android {
       }
     }
 
-    manifestPlaceholders.autoPlayAppCategory = "androidx.car.app.category." + androidAutoAppCategory.toUpperCase()
+    manifestPlaceholders.autoPlayAppCategory = "androidx.car.app.category." + androidAutoAppCategory.toUpperCase(java.util.Locale.ROOT)
 
+    buildConfigField "boolean", "IS_NAVIGATION_APP", isNavigationApp.toString()
     buildConfigField "float", "SCALE_FACTOR", getExtOrDefault("androidAutoScaleFactor")
     buildConfigField "long", "TELEMETRY_UPDATE_INTERVAL", getExtOrDefault("androidTelemetryUpdateInterval")
     buildConfigField "long", "CLUSTER_SPLASH_DELAY_MS", getExtOrDefault("clusterSplashDelayMs")

--- a/packages/react-native-autoplay/android/gradle.properties
+++ b/packages/react-native-autoplay/android/gradle.properties
@@ -5,6 +5,8 @@ ReactNativeAutoPlay_compileSdkVersion=36
 ReactNativeAutoPlay_ndkVersion=27.1.12297006
 # specifies if the Android Auto (androidx.car.app:app-projected) or Automotive (androidx.car.app:app-automotive) library is used
 ReactNativeAutoPlay_isAutomotiveApp=false
+# Android Auto/Automotive app category -> androidx.car.app.category.<UPPERCASE>. Non-navigation values use a lean manifest.
+ReactNativeAutoPlay_androidAutoAppCategory=navigation
 # apply a scale factor on the root view that affects everything rendered by react-native, does not affect templates
 ReactNativeAutoPlay_androidAutoScaleFactor=1.5f
 ReactNativeAutoPlay_androidTelemetryUpdateInterval=4000

--- a/packages/react-native-autoplay/android/src/automotive/AndroidManifest-nonnav.xml
+++ b/packages/react-native-autoplay/android/src/automotive/AndroidManifest-nonnav.xml
@@ -1,0 +1,78 @@
+<!-- Non-navigation Android Automotive manifest; see AndroidManifest.xml for the navigation variant. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-feature
+        android:name="android.hardware.type.automotive"
+        android:required="true" />
+
+    <uses-feature
+        android:name="android.software.car.templates_host"
+        android:required="true" />
+
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+
+
+    <!-- Android Automotive specific permissions -->
+    <uses-permission android:name="android.car.permission.CAR_ENERGY" />
+    <uses-permission android:name="android.car.permission.CAR_ENERGY_PORTS" />
+    <uses-permission android:name="android.car.permission.CAR_EXTERIOR_ENVIRONMENT" />
+    <uses-permission android:name="android.car.permission.CAR_IDENTIFICATION" />
+    <uses-permission android:name="android.car.permission.CAR_INFO" />
+    <uses-permission android:name="android.car.permission.CAR_POWERTRAIN" />
+    <uses-permission android:name="android.car.permission.CAR_SPEED" />
+
+    <application>
+        <activity
+            android:name="androidx.car.app.activity.CarAppActivity"
+            android:exported="true"
+            android:launchMode="singleTask"
+            android:theme="@android:style/Theme.DeviceDefault.NoActionBar">
+
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+            <meta-data
+                android:name="distractionOptimized"
+                android:value="true" />
+
+        </activity>
+
+        <service
+            android:name="com.margelo.nitro.swe.iternio.reactnativeautoplay.AndroidAutoService"
+            android:exported="true"
+            android:foregroundServiceType="location">
+            <intent-filter>
+                <action android:name="androidx.car.app.CarAppService" />
+
+                <category android:name="${autoPlayAppCategory}" />
+            </intent-filter>
+        </service>
+
+        <service android:name="com.margelo.nitro.swe.iternio.reactnativeautoplay.HeadlessTaskService" />
+
+        <activity android:name="com.margelo.nitro.swe.iternio.reactnativeautoplay.SignInWithGoogleActivity" />
+
+        <provider
+            android:name="com.margelo.nitro.swe.iternio.reactnativeautoplay.ActivityRenderStateProvider"
+            android:authorities="${applicationId}.ActivityRenderStateProvider"
+            android:exported="false" />
+
+        <meta-data
+            android:name="com.android.automotive"
+            android:resource="@xml/automotive_app_desc" />
+        <meta-data
+            android:name="androidx.car.app.minCarApiLevel"
+            android:value="1" />
+    </application>
+
+</manifest>

--- a/packages/react-native-autoplay/android/src/main/AndroidManifest-nonnav.xml
+++ b/packages/react-native-autoplay/android/src/main/AndroidManifest-nonnav.xml
@@ -1,0 +1,35 @@
+<!-- Non-navigation Android Auto manifest; see AndroidManifest.xml for the navigation variant. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+
+    <!-- Android Auto specific permissions -->
+    <uses-permission android:name="com.google.android.gms.permission.CAR_FUEL" />
+    <uses-permission android:name="com.google.android.gms.permission.CAR_MILEAGE" />
+    <uses-permission android:name="com.google.android.gms.permission.CAR_SPEED" />
+
+    <application>
+        <service android:name="com.margelo.nitro.swe.iternio.reactnativeautoplay.AndroidAutoService" android:exported="true" android:foregroundServiceType="location">
+            <intent-filter>
+                <action android:name="androidx.car.app.CarAppService" />
+
+                <category android:name="${autoPlayAppCategory}" />
+            </intent-filter>
+        </service>
+
+        <meta-data android:name="com.google.android.gms.car.application" android:resource="@xml/automotive_app_desc" tools:ignore="MetadataTagInsideApplicationTag" />
+        <meta-data android:name="androidx.car.app.minCarApiLevel" android:value="1" />
+
+        <service android:name="com.margelo.nitro.swe.iternio.reactnativeautoplay.HeadlessTaskService" />
+
+        <provider android:name="com.margelo.nitro.swe.iternio.reactnativeautoplay.ActivityRenderStateProvider" android:authorities="${applicationId}.ActivityRenderStateProvider" android:exported="false" />
+    </application>
+</manifest>

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/AndroidAutoService.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/AndroidAutoService.kt
@@ -136,9 +136,14 @@ class AndroidAutoService : CarAppService() {
     private fun createNotification(
         title: String?, text: String?, largeIcon: Bitmap?
     ): Notification {
+        val notificationCategory = if (BuildConfig.IS_NAVIGATION_APP) {
+            NotificationCompat.CATEGORY_NAVIGATION
+        } else {
+            NotificationCompat.CATEGORY_SERVICE
+        }
         return NotificationCompat.Builder(this, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_notification).setOngoing(true)
-            .setCategory(NotificationCompat.CATEGORY_NAVIGATION).setOnlyAlertOnce(true)
+            .setCategory(notificationCategory).setOnlyAlertOnce(true)
             .setWhen(System.currentTimeMillis()).setPriority(NotificationManager.IMPORTANCE_LOW)
             .extend(
                 CarAppExtender.Builder().setImportance(NotificationManagerCompat.IMPORTANCE_LOW)


### PR DESCRIPTION
This PR introduces the option to declare types other than NAVIGATION for Android Auto.

Greetings. I've been working on adding Android Auto support to an application that has
the concept of a schedule. That is, the user has a list of places they need to go and
jobs to do when they get there, that represent their calendar/assignments for the day.
In Apple CarPlay, this is represented as a "Driving Task" app, and we've sought and
already received approval from Apple to publish the app in the app store with that
deisgnation. For Android Auto, though, this library always defaults the declared
type to `NAVIGATION`, which is intended for something like Waze: draw a map, turn by
turn directions, etc. But the app for which I want to use this is not really a maps
application, nor should it be -- it has a list of jobs to be done and a navigate
button that sends the user over to Google Maps (or Waze). If the app I'm working on
is declared as `NAVIGATION` it is rejected in the Google Play store as the testers
are unable to verify how to activate turn by turn directions, et cetera. 

As a workaround in my app I've applied a patch to the library that turns the type
of app into `POI` (which we think is the best match for this use case, even if it
is not a 1:1 match for Apple's Driving Task deisgnation). But then the thought came
to me that I should look to upstream this capability rather than rely on a patch of
the library. I imagined others would benefit from this as well.

According to the docs as of 2026-07-16, there are more types than just navigation
or POI, including messaging, calling, Internet of Things, and weather. 

https://developer.android.com/training/cars

This is, of course, my first (potential) contribution so feedback is welcome.

Acknowledgement: I did get Claude Code to write the changes here.
