### PR TITLE
fix(react-native-autoplay): route CarPlay maneuver estimates correctly

### DIFF
--- a/packages/react-native-autoplay/ios/templates/MapTemplate.swift
+++ b/packages/react-native-autoplay/ios/templates/MapTemplate.swift
@@ -729,11 +729,16 @@ class MapTemplate: AutoPlayHeaderProviding,
                 sessionManeuvers
                 .firstIndex(where: { $0.id == nitroManeuver.id })
             {
+                // `maneuverIndex` indexes `sessionManeuvers` (the filtered,
+                // non-secondary list), so update that same maneuver. Indexing the
+                // unfiltered `navigationSession.upcomingManeuvers` here misrouted
+                // the estimate onto a `-lanes` secondary when lane guidance was
+                // present, leaving the real maneuver stuck on its stale value.
                 navigationSession.updateEstimates(
                     Parser.parseTravelEstimates(
                         travelEstimates: nitroManeuver.travelEstimates
                     ),
-                    for: navigationSession.upcomingManeuvers[maneuverIndex]
+                    for: sessionManeuvers[maneuverIndex]
                 )
 
                 if index != maneuverIndex {
@@ -805,6 +810,23 @@ class MapTemplate: AutoPlayHeaderProviding,
             }
 
             navigationSession.upcomingManeuvers = upcomingManeuvers
+
+            // When a maneuver is promoted to current (e.g. the previous turn just
+            // completed and the next one moves to the front) it is reused, so it
+            // keeps the `initialTravelEstimates` baked in at creation until the
+            // next periodic update arrives. Push the freshest estimate onto the
+            // current maneuver right away so its distance isn't briefly stuck on
+            // the previous turn's value.
+            if let currentManeuver = navigationSession.upcomingManeuvers.first,
+                let currentNitroManeuver = maneuvers.first
+            {
+                navigationSession.updateEstimates(
+                    Parser.parseTravelEstimates(
+                        travelEstimates: currentNitroManeuver.travelEstimates
+                    ),
+                    for: currentManeuver
+                )
+            }
         }
     }
 

--- a/packages/react-native-autoplay/ios/templates/MapTemplate.swift
+++ b/packages/react-native-autoplay/ios/templates/MapTemplate.swift
@@ -729,11 +729,6 @@ class MapTemplate: AutoPlayHeaderProviding,
                 sessionManeuvers
                 .firstIndex(where: { $0.id == nitroManeuver.id })
             {
-                // `maneuverIndex` indexes `sessionManeuvers` (the filtered,
-                // non-secondary list), so update that same maneuver. Indexing the
-                // unfiltered `navigationSession.upcomingManeuvers` here misrouted
-                // the estimate onto a `-lanes` secondary when lane guidance was
-                // present, leaving the real maneuver stuck on its stale value.
                 navigationSession.updateEstimates(
                     Parser.parseTravelEstimates(
                         travelEstimates: nitroManeuver.travelEstimates
@@ -811,12 +806,8 @@ class MapTemplate: AutoPlayHeaderProviding,
 
             navigationSession.upcomingManeuvers = upcomingManeuvers
 
-            // When a maneuver is promoted to current (e.g. the previous turn just
-            // completed and the next one moves to the front) it is reused, so it
-            // keeps the `initialTravelEstimates` baked in at creation until the
-            // next periodic update arrives. Push the freshest estimate onto the
-            // current maneuver right away so its distance isn't briefly stuck on
-            // the previous turn's value.
+            // CarPlay only applies an estimate update if the maneuver is already active,
+            // since we set new upcomingManeuvers we need to apply the latest travelEstimates on the active maneuver here
             if let currentManeuver = navigationSession.upcomingManeuvers.first,
                 let currentNitroManeuver = maneuvers.first
             {


### PR DESCRIPTION
## Summary

Fixes two CarPlay travel-estimate bugs in `MapTemplate.swift`:

- **Estimate misrouted onto lane secondary.** The update indexed the unfiltered `navigationSession.upcomingManeuvers` with an index (`maneuverIndex`) computed against the *filtered* `sessionManeuvers` (non-secondary) list. When lane guidance was present, `-lanes` secondary maneuvers shifted the indices, so the estimate landed on a secondary maneuver and the real maneuver stayed stuck on its stale value. Now updates `sessionManeuvers[maneuverIndex]`.
- **Stale distance on maneuver promotion.** When a maneuver is promoted to current (previous turn completes, next moves to front) it is reused and keeps the `initialTravelEstimates` baked in at creation until the next periodic update. We now push the freshest estimate onto the current maneuver immediately, so its distance isn't briefly stuck on the previous turn's value.

## Test plan

- [x] Test in the car and make sure the instruction has proper distance in HUD when it updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)