### PR TITLE
fix: avoid releasing display too early to prevent freezes on some devices

### DIFF
--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/VirtualRenderer.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/VirtualRenderer.kt
@@ -41,6 +41,7 @@ class VirtualRenderer(
     private val isCluster: Boolean = false
 ) {
     private var virtualDisplay: VirtualDisplay? = null
+    private val pendingDisplays = mutableListOf<VirtualDisplay>()
 
     private var reactSurfaceImpl: ReactSurfaceImpl? = null
     private var reactSurfaceView: ReactSurfaceView? = null
@@ -92,8 +93,8 @@ class VirtualRenderer(
                 stableArea = Rect(0, 0, 0, 0)
                 visibleArea = Rect(0, 0, 0, 0)
 
-                virtualDisplay?.release()
-                virtualDisplay = null
+                // Not releasing virtualDisplay here, and not relying on this firing at all (unreliable on
+                // some Automotive devices) -- see applySurface/onDraw sweep for where the old display actually gets freed.
             }
 
             override fun onScroll(distanceX: Float, distanceY: Float) {
@@ -236,10 +237,15 @@ class VirtualRenderer(
         // surface itself is kept alive so JS state survives the resize; the JS side is informed
         // via the windowInformation listener since the window initial prop stays stale.
         val isResize = reactSurfaceView != null && (width != surfaceWidth
-            || height != surfaceHeight || dpi != surfaceContainer.dpi)
+                || height != surfaceHeight || dpi != surfaceContainer.dpi)
 
         val manager = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
-        virtualDisplay?.release()
+
+        virtualDisplay?.let {
+            // released once its replacement (created below) has drawn
+            pendingDisplays.add(it)
+        }
+
         virtualDisplay = manager.createVirtualDisplay(
             moduleName,
             surfaceWidth,
@@ -415,6 +421,23 @@ class VirtualRenderer(
                 rootContainer.addView(it)
             }
 
+            rootContainer.viewTreeObserver.addOnDrawListener(object :
+                ViewTreeObserver.OnDrawListener {
+                override fun onDraw() {
+                    rootContainer.post {
+                        rootContainer.viewTreeObserver.removeOnDrawListener(this)
+                        // Releasing here, only once a new display has drawn, avoids the window-absent gap that
+                        // stops Choreographer. Releasing old displays any earlier reintroduces that suspension. It
+                        // freezes the map (Mapbox ValueAnimator) and RN (setInterval/setTimeout) until the phone
+                        // screen is woken.
+                        pendingDisplays.forEach {
+                            it.release()
+                        }
+                        pendingDisplays.clear()
+                    }
+                }
+            })
+
             setContentView(rootContainer)
         }
     }
@@ -490,6 +513,13 @@ class VirtualRenderer(
     private fun stop() {
         virtualDisplay?.release()
         virtualDisplay = null
+
+        pendingDisplays.forEach {
+            // make sure to release any pending displays in case
+            // the new one did not draw yet but stop is called
+            it.release()
+        }
+        pendingDisplays.clear()
 
         try {
             stopReactSurface()


### PR DESCRIPTION
## Problem
On some Samsung devices (confirmed: Galaxy S25, Android 16), the
Android Auto map and RN components could freeze indefinitely. Root cause:
Samsung's BBA power-management logic suspends the main thread's
Choreographer if it sees the app's window disappear, even briefly.
VirtualRenderer used to release the outgoing VirtualDisplay/Presentation
in onSurfaceDestroyed -- which could leave no AA window registered
while a full-screen template was shown.

Once suspended, everything riding on Choreographer stops: Mapbox's
ValueAnimator-driven camera/puck, RN's setInterval/setTimeout, and RN
view layout/draw for components. Nothing crashes -- it just goes
silent until something resets Samsung's classifier (e.g. waking the
phone screen).

https://github.com/user-attachments/assets/06a106f4-e3e5-4c3c-bafc-3d2eccfa059e

## Fix
Stop releasing displays in onSurfaceDestroyed (also not reliably
invoked on all hosts). Instead, stash the outgoing display and only
release it once the replacement Presentation has confirmed a drawn
frame, so the AA window is never absent even momentarily.

https://github.com/user-attachments/assets/b9b09a0d-08a1-4d8b-81f5-68640d85309e

