### PR TITLE
feat(android): native backdrop hook under the MapTemplate surface

### DIFF
--- a/packages/react-native-autoplay/README.md
+++ b/packages/react-native-autoplay/README.md
@@ -203,6 +203,40 @@ In case you have ProGuard enabled (`def enableProguardInReleaseBuilds = true` in
 -keep class com.margelo.nitro.swe.iternio.reactnativeautoplay.** { *; }
 ```
 
+#### Native backdrop under the MapTemplate surface
+On Android the React content of a `MapTemplate` is rendered onto the car screen through a virtual display. Some native views cannot be hosted there as React Native views — Fragment-based map SDK wrappers, for example, are bound to the phone `Activity`. For those the library can place a host-provided native `View` **under** the React surface of the root display: the Android counterpart of the iOS `getRootViewForAutoplay` hook above. Your React tree then draws on top of it as an overlay. This applies to the root display only, not to cluster displays.
+
+```kotlin
+interface NativeBackdrop {
+    /** Added as the presentation root's FIRST child, match-parent. */
+    val view: View
+
+    /** The car's day/night changed (CarContext.isDarkMode) — redraw accordingly. */
+    fun onColorSchemeChanged(dark: Boolean)
+
+    /** Release everything; must be idempotent. */
+    fun destroy()
+}
+
+object NativeBackdropRegistry {
+    @Volatile
+    var factory: ((CarContext) -> NativeBackdrop)? = null
+}
+```
+
+Register the factory in your `Application.onCreate`, before the `CarAppService` can start:
+
+```kotlin
+NativeBackdropRegistry.factory = { carContext -> MyMapBackdrop(carContext) }
+```
+
+Lifecycle contract:
+
+-   The factory is consulted once per presentation — i.e. again after every surface resize — and each backdrop is destroyed when its presentation is replaced or the renderer stops.
+-   A factory that throws is logged and ignored; the React surface still renders.
+-   The React surface view is transparent only while a backdrop is attached. Without a registered factory nothing changes: the surface stays opaque as before.
+-   `onColorSchemeChanged(dark)` is forwarded from `Session.onCarConfigurationChanged`, so the backdrop can follow the car's day/night setting (car app quality guideline MR-1). It fires regardless of which template is currently on screen.
+
 ### Android Auto Customization
 You can customize certain behaviors of the library on Android Auto by setting properties in your app's `android/gradle.properties` file.
 

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/AndroidAutoSession.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/AndroidAutoSession.kt
@@ -113,6 +113,13 @@ class AndroidAutoSession(sessionInfo: SessionInfo) :
     override fun onCarConfigurationChanged(configuration: Configuration) {
         val colorScheme = if (carContext.isDarkMode) ColorScheme.DARK else ColorScheme.LIGHT
 
+        // The root display's native backdrop must follow the car's day/night (car-app quality
+        // MR-1). Forwarded before the early returns below — the root template may not be a
+        // MapTemplate yet (e.g. a pre-trip MessageTemplate) and must still switch.
+        if (clusterId == null) {
+            VirtualRenderer.onColorSchemeChanged(ROOT_SESSION, carContext.isDarkMode)
+        }
+
         if (clusterId != null) {
             HybridCluster.emitColorScheme(clusterId, colorScheme)
             AndroidAutoScreen.getScreen(clusterId)?.applyConfigUpdate(invalidate = true)

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/NativeBackdrop.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/NativeBackdrop.kt
@@ -1,0 +1,32 @@
+package com.margelo.nitro.swe.iternio.reactnativeautoplay
+
+import android.view.View
+import androidx.car.app.CarContext
+
+/**
+ * An optional host-app-provided native View rendered under the React surface of the
+ * Android Auto root display — the Android counterpart of the iOS `getRootViewForAutoplay`
+ * AppDelegate hook. Lets a host compose a native map beneath its React overlay, e.g. a
+ * native map view that cannot be hosted as a React Native view on the virtual display
+ * (Fragment-based map SDK wrappers are bound to the phone Activity).
+ *
+ * Contract: register `NativeBackdropRegistry.factory` before the CarAppService starts
+ * (Application.onCreate). The factory is consulted once per presentation (i.e. again after
+ * every surface resize); each backdrop is destroyed when its presentation is replaced or the
+ * renderer stops. A factory that throws is logged and ignored — the surface still renders.
+ */
+interface NativeBackdrop {
+    /** Added as the presentation root's FIRST child, match-parent. */
+    val view: View
+
+    /** The car's day/night changed (CarContext.isDarkMode) — redraw accordingly. */
+    fun onColorSchemeChanged(dark: Boolean)
+
+    /** Release everything; must be idempotent. */
+    fun destroy()
+}
+
+object NativeBackdropRegistry {
+    @Volatile
+    var factory: ((CarContext) -> NativeBackdrop)? = null
+}

--- a/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/VirtualRenderer.kt
+++ b/packages/react-native-autoplay/android/src/main/java/com/margelo/nitro/swe/iternio/reactnativeautoplay/VirtualRenderer.kt
@@ -7,6 +7,7 @@ import android.graphics.Rect
 import android.hardware.display.DisplayManager
 import android.hardware.display.VirtualDisplay
 import android.os.Bundle
+import android.util.Log
 import android.view.ContextThemeWrapper
 import android.view.Display
 import android.view.LayoutInflater
@@ -42,6 +43,10 @@ class VirtualRenderer(
 ) {
     private var virtualDisplay: VirtualDisplay? = null
     private val pendingDisplays = mutableListOf<VirtualDisplay>()
+    // Optional host view under the React surface (see NativeBackdrop), one per presentation;
+    // parked ones are destroyed in the same sweep as pendingDisplays
+    private var currentBackdrop: NativeBackdrop? = null
+    private val pendingBackdrops = mutableListOf<NativeBackdrop>()
 
     private var reactSurfaceImpl: ReactSurfaceImpl? = null
     private var reactSurfaceView: ReactSurfaceView? = null
@@ -408,14 +413,41 @@ class VirtualRenderer(
             }
 
 
+            // Ask the host for a native backdrop for the root display (clusters never get one).
+            // `this@VirtualRenderer.context` is the CarContext — the presentation's own `context`
+            // parameter is the ReactContext and shadows it. A throwing factory is logged and
+            // ignored so the React surface still renders.
+            val backdrop: NativeBackdrop? = if (!isCluster) {
+                NativeBackdropRegistry.factory?.let { factory ->
+                    runCatching { factory(this@VirtualRenderer.context) }
+                        .onFailure { Log.w(TAG, "native backdrop factory failed; rendering without it", it) }
+                        .getOrNull()
+                }
+            } else {
+                null
+            }
+            currentBackdrop?.let { pendingBackdrops.add(it) }
+            currentBackdrop = backdrop
+
             val rootContainer = FrameLayout(themedContext).apply {
                 layoutParams = FrameLayout.LayoutParams(
                     FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT
                 )
                 clipChildren = false
 
+                backdrop?.let {
+                    // A view the host hands out more than once must not crash Presentation.onCreate
+                    (it.view.parent as? ViewGroup)?.removeView(it.view)
+                    addView(it.view, FrameLayout.LayoutParams(
+                        FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT
+                    ))
+                }
                 addView(reactSurfaceView)
             }
+            // The surface view is painted opaque DKGRAY at construction and survives resizes by
+            // re-parenting, so (re)apply per presentation: see-through only while a backdrop is
+            // actually attached.
+            reactSurfaceView?.setBackgroundColor(if (backdrop != null) Color.TRANSPARENT else Color.DKGRAY)
 
             splashScreenView?.let {
                 rootContainer.addView(it)
@@ -434,6 +466,9 @@ class VirtualRenderer(
                             it.release()
                         }
                         pendingDisplays.clear()
+                        // Backdrops share the lifetime of the displays they drew on
+                        pendingBackdrops.forEach { it.destroy() }
+                        pendingBackdrops.clear()
                     }
                 }
             })
@@ -511,6 +546,13 @@ class VirtualRenderer(
 
     @MainThread
     private fun stop() {
+        // Current and parked — a stop during a resize must not leak the backdrop whose
+        // replacement never drew
+        currentBackdrop?.destroy()
+        currentBackdrop = null
+        pendingBackdrops.forEach { it.destroy() }
+        pendingBackdrops.clear()
+
         virtualDisplay?.release()
         virtualDisplay = null
 
@@ -553,6 +595,11 @@ class VirtualRenderer(
         fun removeRenderer(moduleId: String) {
             virtualRenderer[moduleId]?.stop()
             virtualRenderer.remove(moduleId)
+        }
+
+        // Forwarded by AndroidAutoSession.onCarConfigurationChanged
+        fun onColorSchemeChanged(moduleId: String, dark: Boolean) {
+            virtualRenderer[moduleId]?.currentBackdrop?.onColorSchemeChanged(dark)
         }
     }
 }


### PR DESCRIPTION
## Why

On Android the React content of a `MapTemplate` is rendered onto the car screen through
a virtual display. Some native views cannot be hosted there as React Native views —
Fragment-based map SDK wrappers are bound to the phone `Activity`, so mounting one on the
virtual display's presentation fails. On iOS a host can already put anything it likes
under the React content via the `getRootViewForAutoplay` AppDelegate hook; Android has no
counterpart.

This PR adds that counterpart: a host-provided native `View` rendered **under** the React
surface of the root display, so a native map (or any other native view) can sit beneath
the app's React overlay. Discussed in #119.

## What

- **`NativeBackdrop` interface** (`view`, `onColorSchemeChanged(dark)`, `destroy()`) and
  **`NativeBackdropRegistry.factory: ((CarContext) -> NativeBackdrop)?`**, registered by
  the host in `Application.onCreate` before the `CarAppService` can start.
- **Per-presentation host / teardown in `VirtualRenderer`.** The factory is consulted once
  per presentation (so again after every surface resize), root display only — clusters
  never get one. The view is added as the presentation root's first child, match-parent,
  under the `ReactSurfaceView`. The previous backdrop is parked alongside the display it
  drew on and destroyed in the same sweep as `pendingDisplays`; `stop()` destroys both the
  current and any parked backdrops so a stop during a resize cannot leak one.
- **Fault isolation.** A factory that throws is logged (`Log.w`) and ignored; the React
  surface still renders.
- **Re-parent hardening.** A view the host hands out more than once is detached from its
  previous parent before being added, instead of crashing `Presentation.onCreate`.
- **Transparent surface view while attached.** `ReactSurfaceView` is painted opaque
  `DKGRAY` at construction and survives resizes by re-parenting, so the background is now
  (re)applied per presentation: `TRANSPARENT` while a backdrop is attached, `DKGRAY`
  otherwise.
- **Color-scheme forward.** `AndroidAutoSession.onCarConfigurationChanged` forwards
  `carContext.isDarkMode` to the current root backdrop *before* its template-specific
  early returns, so the backdrop follows the car's day/night (car app quality MR-1)
  whatever the root template currently is (e.g. a pre-trip `MessageTemplate`).
- **README:** new "Native backdrop under the MapTemplate surface" subsection in the
  Android Auto setup section — interface, registration point, lifecycle contract.

No TypeScript / Nitro spec changes; no iOS changes; no new dependencies
(`androidx.car.app.CarContext` is already on the library's classpath).

## How verified

- Compiled in a real Expo SDK 57 app (RN 0.86, New Architecture) via Gradle
  `assembleRelease`, with a host `NativeBackdrop` wrapping a Fragment-free native map view
  (Google Navigation SDK `NavigationViewForAuto`) registered from `Application.onCreate`.
- Desktop Head Unit, debuggable build, simulated drive — all passed:
  - [x] 1. Backdrop paints under the maneuver/ETA cards at the correct scale (presentation
        built on the `ReactContext`, backdrop on the `CarContext` — no density/letterbox
        mismatch on an 800×400 @160 dpi surface).
  - [x] 2. Simulated drive: backdrop animates; React overlay and the host-drawn template
        (maneuver cards, lanes, ETA) unchanged.
  - [x] 3. DHU `night` / `day` mid-drive → `onColorSchemeChanged` delivered both ways
        (verified via the host's own log), including while the root template is not a
        `MapTemplate`.
  - [x] 4. Home the phone app and reopen → no fatal, backdrop persists (not activity-bound).
  - [x] 5. Phone screen locked ≥ 2 min → backdrop still animating.
  - [x] 6. DHU disconnect/reconnect → previous backdrop destroyed in the sweep, fresh one
        created for the new presentation; `logcat` free of leaked-window /
        `IllegalStateException` noise. (Two consecutive resizes and a `dumpsys meminfo`
        growth check were not exercised on the DHU.)
  - [x] 7. Surface shows the backdrop wherever the React tree is transparent — no stray
        opaque background.

## Compatibility

No behavior change when no factory is registered (the default). On that path the only
diff is `reactSurfaceView.setBackgroundColor(Color.DKGRAY)` being re-applied per
presentation, which equals the value the view already has. Clusters are untouched
(`isCluster` short-circuits the factory lookup). The color-scheme forward is a no-op
when `currentBackdrop` is null.

One observation from the same integration, not part of this PR: on Android the
`AssetImage` `scale`/`width`/`height` fields are not applied — `parseAssetImage` hands
the decoded bitmap straight to `CarIcon`, so a host must supply bitmaps at the car
surface's density itself. Happy to open a separate issue if useful.
